### PR TITLE
Rename Utils to Prelude

### DIFF
--- a/Prelude.lean
+++ b/Prelude.lean
@@ -1,0 +1,2 @@
+
+import Prelude.List

--- a/Prelude/List.lean
+++ b/Prelude/List.lean
@@ -1,7 +1,5 @@
 
-universe u v w
-
-variable {A : Type u} {B : Type v} {C : Type w}
+variable {A : Type u} {B : Type v} {C : Type w} {D : Type z}
 
 def List.zipWith3Exact (f : A → B → C → D) (l1 : List A) (l2 : List B) (l3 : List C) : List D :=
   match l1, l2, l3 with

--- a/Utils.lean
+++ b/Utils.lean
@@ -1,2 +1,0 @@
-
-import Utils.List

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,6 +1,6 @@
 name = "goose"
 version = "0.1.0"
-defaultTargets = ["Utils", "Anoma", "Goose"]
+defaultTargets = ["Prelude", "Anoma", "Goose"]
 
 [[lean_lib]]
 name = "Goose"
@@ -9,4 +9,4 @@ name = "Goose"
 name = "Anoma"
 
 [[lean_lib]]
-name = "Utils"
+name = "Prelude"


### PR DESCRIPTION
I think the name Prelude more strongly suggests that it is expected to contain generic functions not tied to Goose or Anoma