### PR TITLE
Set relaxedAutoImplicit to false

### DIFF
--- a/Goose/Class/Member.lean
+++ b/Goose/Class/Member.lean
@@ -47,8 +47,8 @@ def Class.Member.AppData.toSomeAppData {pub : Public} {Args : Type u}
 def Class.Method.AppData (sig : Signature) (method : Class.Method sig) :=
   Member.AppData sig.pub method.Args
 
-def Class.Constructor.AppData (pub : Public) (constr : Class.Constructor sig) :=
-  Member.AppData pub constr.Args
+def Class.Constructor.AppData {sig : Signature} (constr : Class.Constructor sig) :=
+  Member.AppData sig.pub constr.Args
 
 instance Class.Member.AppData.RawInstance (pub : Public) {Args : Type u} [Anoma.Raw Args]
    : Anoma.Raw (Class.Member.AppData pub Args) where

--- a/Goose/Class/Translation.lean
+++ b/Goose/Class/Translation.lean
@@ -68,7 +68,7 @@ def Action.create.old {sig : Signature} {Args : Type} [rawArgs : Anoma.Raw Args]
 /-- Creates a logic for a given constructor. This logic is combined with other
     method and constructor logics to create the complete resource logic for an
     object. -/
-def Class.Constructor.logic (sig : Signature) (constr : Class.Constructor sig) (args : Anoma.Logic.Args (constr.AppData sig.pub)) : Bool :=
+def Class.Constructor.logic (sig : Signature) (constr : Class.Constructor sig) (args : Anoma.Logic.Args constr.AppData) : Bool :=
   let argsData : constr.Args := args.data.args
   let newObj := constr.created argsData
   if args.isConsumed then

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -2,6 +2,9 @@ name = "goose"
 version = "0.1.0"
 defaultTargets = ["Utils", "Anoma", "Goose"]
 
+[leanOptions]
+relaxedAutoImplicit = false
+
 [[lean_lib]]
 name = "Goose"
 


### PR DESCRIPTION
I think this is a saner default, and I have already caught one typo with it.

From the documentation:

> Automatic implicit parameters insertion is controlled by two options. By default, automatic implicit parameter insertion is relaxed, which means that any unbound identifier may be a candidate for automatic insertion. Setting the option [relaxedAutoImplicit](https://lean-lang.org/doc/reference/latest/Definitions/Headers-and-Signatures/#relaxedAutoImplicit) to [false](https://lean-lang.org/doc/reference/latest/Basic-Types/Booleans/#Bool___false) disables relaxed mode and causes only identifiers that consist of a single character followed by zero or more digits to be considered for automatic insertion.