### PR TITLE
Ease traits for Args types to be inferred

### DIFF
--- a/Apps/UniversalCounter.lean
+++ b/Apps/UniversalCounter.lean
@@ -26,19 +26,11 @@ def lab : Class.Label where
   priv := {PrivateFields := Nat}
   pub := {PublicFields := Unit}
   MethodId := Methods
-  MethodArgs := fun
-    | Methods.Incr => Nat
-  repMethodArgs := fun
-    | Methods.Incr => inferInstance
-  beqMethodArgs := fun
-    | Methods.Incr => inferInstance
+  MethodArgsTypes := fun
+    | Methods.Incr => {type := Nat}
   ConstructorId := Constructors
-  ConstructorArgs := fun
-    | Constructors.Zero => Unit
-  repConstructorArgs := fun
-    | Constructors.Zero => inferInstance
-  beqConstructorArgs := fun
-    | Constructors.Zero => inferInstance
+  ConstructorArgsTypes := fun
+    | Constructors.Zero => {type := Unit}
   name := "UniversalCounter"
 
 def toObject (c : Counter) : Object lab where


### PR DESCRIPTION
This small refactor makes it easier to provide the signature for an application by making it possible for lean to infer the instances of the needed traits