### PR TITLE
Rename extraLogic and created in Applib

### DIFF
--- a/AVM/Class.lean
+++ b/AVM/Class.lean
@@ -10,9 +10,9 @@ structure Class (lab : Class.Label) where
   constructors : (c : lab.ConstructorId) -> Class.Constructor c
   methods : (m : lab.MethodId) -> Class.Method m
   /-- Extra class-specific logic. The whole resource logic function for an
-     object consists of the class logic and the method and constructor logics.
+     object consists of the class invariant and the method and constructor logics.
      -/
-  extraLogic : (self : Object lab) → Anoma.Logic.Args lab.pub.PublicFields → Bool
+  invariant : (self : Object lab) → Anoma.Logic.Args lab.pub.PublicFields → Bool
 
 /-- The class app data consists of member logic (indicator which member is being
     called) and member app data. -/

--- a/AVM/Class/Label.lean
+++ b/AVM/Class/Label.lean
@@ -31,10 +31,15 @@ structure ArgsType where
   [rep : TypeRep type]
   [beq : BEq type]
 
+/-- A class label uniquely identifies and specifies a class. The class
+    specification provided by a label consists of unique class name, private and
+    public field types, constructor and method ids. -/
 structure Label where
+  /-- The name of the class uniquely identifying the class.
+      Assumption: lab1.name = lab2.name -> lab1 = lab2. -/
+  name : String
   priv : Private
   pub : Public
-  name : String
 
   MethodId : Type
   [methodsFinite : Fintype MethodId]
@@ -83,6 +88,6 @@ instance Label.hasTypeRep : TypeRep Label where
 
 instance Label.hasBEq : BEq Label where
   beq a b :=
-    a.priv == b.priv
+    a.name == b.name
+    && a.priv == b.priv
     && a.pub == b.pub
-    && a.name == b.name

--- a/AVM/Class/Member.lean
+++ b/AVM/Class/Member.lean
@@ -7,16 +7,16 @@ def Constructor.Args {lab : Label} (constrId : lab.ConstructorId) : Type :=
   lab.ConstructorArgs constrId
 
 structure Constructor {lab : Label} (constrId : lab.ConstructorId) where
-  /-- Extra constructor logic. It is combined with auto-generated constructor
-      logic to create the complete constructor logic. -/
-  extraLogic : constrId.Args → Bool
+  /-- Extra constructor logic. The constructor invariant is combined with
+      auto-generated constructor body constraints to create the constructor logic. -/
+  invariant : constrId.Args → Bool
   /-- Objects created in the constructor call. -/
   created : constrId.Args → Object lab
 
 structure Method {lab : Label} (methodId : lab.MethodId) where
-  /-- Extra method logic. It is combined with auto-generated method logic to
-      create the complete method logic. -/
-  extraLogic : (self : Object lab) → methodId.Args → Bool
+  /-- Extra method logic. The method invariant is combined with auto-generated
+      method body constraints to create the method logic. -/
+  invariant : (self : Object lab) → methodId.Args → Bool
   /-- Objects created in the method call. -/
   created : (self : Object lab) → methodId.Args → List SomeObject
 

--- a/AVM/Class/Translation.lean
+++ b/AVM/Class/Translation.lean
@@ -62,7 +62,7 @@ def Constructor.logic {lab : Label} {constrId : lab.ConstructorId}
     if args.isConsumed then
       Class.Member.Logic.checkResourceData [newObj.toSomeObject] args.consumed
         && Class.Member.Logic.checkResourceData [newObj.toSomeObject] args.created
-        && constr.extraLogic argsData
+        && constr.invariant argsData
     else
       -- TODO: not general enough, fine for the counter
       True
@@ -108,7 +108,7 @@ def Method.logic {lab : Label} {methodId : lab.MethodId}
         if args.isConsumed then
           Class.Member.Logic.checkResourceData [selfObj.toSomeObject] args.consumed
             && Class.Member.Logic.checkResourceData createdObjects args.created
-            && method.extraLogic selfObj argsData
+            && method.invariant selfObj argsData
         else
           -- NOTE thise branch is never hit because we don't add AppData for created resources
           -- TODO: may need to do something more here in general, fine for the counter

--- a/Applib.lean
+++ b/Applib.lean
@@ -23,23 +23,21 @@ instance {ty : Type} [IsObject ty] : CoeHead ty AnObject where
   coe (obj : ty) := {obj}
 
 def defMethod {cl : Type} [i : IsObject cl] {methodId : i.lab.MethodId}
- -- TODO rename created to body
- (created : (self : cl) -> methodId.Args -> List AnObject)
- (extraLogic : (self : cl) -> methodId.Args -> Bool := fun _ _ => True)
+ (body : (self : cl) -> methodId.Args -> List AnObject)
+ (invariant : (self : cl) -> methodId.Args -> Bool := fun _ _ => True)
  : Class.Method methodId where
-    extraLogic (self : Object i.lab) (args : methodId.Args) :=
+    invariant (self : Object i.lab) (args : methodId.Args) :=
       match i.fromObject self with
         | none => False
-        | (some self') => extraLogic self' args
+        | (some self') => invariant self' args
     created (self : Object i.lab) (args : methodId.Args) :=
       match i.fromObject self with
         | none => []
-        | (some self') => List.map AnObject.toSomeObject (created self' args)
+        | (some self') => List.map AnObject.toSomeObject (body self' args)
 
 def defConstructor {cl : Type} [i : IsObject cl] {constrId : i.lab.ConstructorId}
- (created : constrId.Args -> cl)
- -- TODO rename extraLogic to extraConstraints
- (extraLogic : constrId.Args -> Bool)
+ (body : constrId.Args -> cl)
+ (invariant : constrId.Args -> Bool := fun _ => True)
  : Class.Constructor constrId where
-    extraLogic (args : constrId.Args) := extraLogic args
-    created (args : constrId.Args) := i.toObject (created args)
+    invariant (args : constrId.Args) := invariant args
+    created (args : constrId.Args) := i.toObject (body args)

--- a/Apps/UniversalCounter.lean
+++ b/Apps/UniversalCounter.lean
@@ -23,6 +23,7 @@ deriving instance Inhabited for Counter
 open AVM
 
 def lab : Class.Label where
+  name := "UniversalCounter"
   priv := {PrivateFields := Nat}
   pub := {PublicFields := Unit}
   MethodId := Methods
@@ -31,7 +32,6 @@ def lab : Class.Label where
   ConstructorId := Constructors
   ConstructorArgsTypes := fun
     | Constructors.Zero => {type := Unit}
-  name := "UniversalCounter"
 
 def toObject (c : Counter) : Object lab where
   publicFields := Unit.unit

--- a/Apps/UniversalCounter.lean
+++ b/Apps/UniversalCounter.lean
@@ -55,16 +55,14 @@ def incrementBy (step : Nat) (c : Counter) : Counter :=
   {c with count := c.count + step}
 
 def counterConstructor : @Class.Constructor lab Constructors.Zero := defConstructor
-  (created := fun (_noArgs : Unit) => newCounter)
-  (extraLogic := fun (_noArgs : Unit) => True)
+  (body := fun (_noArgs : Unit) => newCounter)
 
 def counterIncr : @Class.Method lab Methods.Incr := defMethod
-  (created := fun (self : Counter) (step : Nat) => [self.incrementBy step])
-  (extraLogic := fun _ _ => True)
+  (body := fun (self : Counter) (step : Nat) => [self.incrementBy step])
 
 def counterClass : Class lab where
   constructors := fun
     | Constructors.Zero => counterConstructor
   methods := fun
     | Methods.Incr => counterIncr
-  extraLogic _ _ := True
+  invariant _ _ := True


### PR DESCRIPTION
- Renames `extraLogic` to `invariant` everywhere
- Renames `created` to `body` in `defMethod` and `defConstructor` in Applib
- Adds a few explanatory comments
