### PR TITLE
Remove public fields

### DIFF
--- a/AVM/Class/AppData.lean
+++ b/AVM/Class/AppData.lean
@@ -7,12 +7,10 @@ namespace AVM.Class
 /-- The app data for an object in a given class consists of:
     1. member logic indicator (indicator which member is being called)
     2. member arguments
-    3. public fields of the object
   -/
 structure AppData (lab : Label) where
   memberId : lab.MemberId
   memberArgs : memberId.Args.type
-  publicFields : lab.PublicFields.type
 
 structure SomeAppData where
   {label : Label}
@@ -22,8 +20,7 @@ def AppData.toSomeAppData {lab : Label} (appData : Class.AppData lab) : Class.So
 
 instance AppData.hasBEq {lab : Label} : BEq (Class.AppData lab) where
   beq a b :=
-    a.publicFields === b.publicFields
-    && a.memberId == b.memberId
+    a.memberId == b.memberId
     && a.memberArgs === b.memberArgs
 
 instance AppData.hasTypeRep {lab : Label} : TypeRep (Class.AppData lab) where
@@ -36,16 +33,3 @@ instance SomeAppData.hasTypeRep : TypeRep Class.SomeAppData where
   rep := Rep.atomic "AVM.Class.SomeAppData"
 
 abbrev Logic.Args (lab : Label) := Anoma.Logic.Args (Class.AppData lab)
-
-def SomeObject.fromResourceWithAppData
-  (res : Anoma.Resource)
-  (someAppData : SomeAppData)
-  : Option SomeObject := do
-  let resLab : Object.Resource.Label ← tryCast res.label
-  let lab : Class.Label := resLab.classLabel
-  match SomeType.cast someAppData.appData.publicFields with
-  | none => none
-  | some (publicFields : lab.PublicFields.type) =>
-    match Object.fromResource publicFields res with
-    | none => none
-    | some obj => pure {label := lab, object := obj}

--- a/AVM/Class/Label.lean
+++ b/AVM/Class/Label.lean
@@ -14,15 +14,14 @@ instance DynamicLabel.instInhabited {A : Type u} : Inhabited (DynamicLabel A) wh
               mkDynamicLabel := fun _ => default}
 
 /-- A class label uniquely identifies and specifies a class. The class
-    specification provided by a label consists of unique class name, private and
-    public field types, constructor and method ids. -/
+    specification provided by a label consists of unique class name, private
+    field types, constructor and method ids. -/
 structure Label : Type (u + 1) where
   /-- The name of the class uniquely identifying the class.
       Assumption: lab1.name = lab2.name -> lab1 = lab2. -/
   name : String
 
   PrivateFields : SomeType.{u}
-  PublicFields : SomeType.{u}
 
   /-- The dynamic label is used to put dynamic data into the Resource label -/
   DynamicLabel : DynamicLabel.{u} PrivateFields.type := default
@@ -113,4 +112,3 @@ instance Label.hasBEq : BEq Label where
   beq a b :=
     a.name == b.name
     && a.PrivateFields == b.PrivateFields
-    && a.PublicFields == b.PublicFields

--- a/AVM/Class/Translation.lean
+++ b/AVM/Class/Translation.lean
@@ -34,8 +34,7 @@ private def Action.create (lab : Label) (memberId : Label.MemberId lab) (args : 
       (Anoma.Tag.Consumed i.nullifierProof.nullifier,
         { appData := {
             memberId,
-            memberArgs := args,
-            publicFields := i.object.publicFields }})
+            memberArgs := args }})
 
     mkTagDataPairCreated (i : CreatedObject)
      : Anoma.Tag × Class.SomeAppData :=
@@ -43,8 +42,7 @@ private def Action.create (lab : Label) (memberId : Label.MemberId lab) (args : 
         {label := i.label,
          appData := {
           memberId := Label.MemberId.falseLogicId,
-          memberArgs := UUnit.unit,
-          publicFields := i.object.publicFields }})
+          memberArgs := UUnit.unit }})
 
 /-- Creates a logic for a given constructor. This logic is combined with other
     method and constructor logics to create the complete resource logic for an
@@ -102,7 +100,7 @@ def Method.logic {lab : Label} {methodId : lab.MethodId}
     if args.isConsumed then
       match SomeType.cast args.data.memberArgs with
       | some argsData =>
-        let mselfObj : Option (Object lab) := Object.fromResource args.data.publicFields args.self
+        let mselfObj : Option (Object lab) := Object.fromResource args.self
         match mselfObj with
           | none => false
           | some selfObj =>
@@ -151,7 +149,7 @@ def Destructor.logic {lab : Label} {destructorId : lab.DestructorId}
     if args.isConsumed then
       match SomeType.cast args.data.memberArgs with
       | some argsData =>
-        let mselfObj : Option (Object lab) := Object.fromResource args.data.publicFields args.self
+        let mselfObj : Option (Object lab) := Object.fromResource args.self
         match mselfObj with
           | none => false
           | some selfObj =>
@@ -218,7 +216,7 @@ private def logic' {lab : Label} (cls : Class lab) (args : Class.Logic.Args lab)
     -- 1. member logic corresponding to the memberId in AppData
     -- 2. class invariant for the object being consumed
     BoolCheck.run do
-      let selfObj : Object lab ← BoolCheck.some (Object.fromResource args.data.publicFields args.self)
+      let selfObj : Object lab ← BoolCheck.some (Object.fromResource args.self)
       BoolCheck.ret <|
         checkMemberLogic args.data.memberId
         && cls.invariant selfObj args

--- a/AVM/Intent/Translation.lean
+++ b/AVM/Intent/Translation.lean
@@ -13,11 +13,7 @@ def Intent.logic (intent : Intent) (args : Anoma.Logic.Args Unit) : Bool :=
   if args.isConsumed then
     BoolCheck.run do
       let data ← BoolCheck.some <| Intent.ResourceData.fromResource args.self
-      -- We use fake values for public fields of created objects. Public fields
-      -- for created resources are not available, because they are stored in app
-      -- data and in RL arguments app data is available only for the `self`
-      -- resource.
-      let receivedObjects ← BoolCheck.some <| List.mapSome (SomeObject.fromResource (PublicFields := ⟨Unit⟩) ()) args.created
+      let receivedObjects ← BoolCheck.some <| List.mapSome SomeObject.fromResource args.created
       let argsData ← BoolCheck.some <| tryCast data.args
       BoolCheck.ret <|
         intent.condition argsData data.provided receivedObjects
@@ -59,8 +55,7 @@ def Intent.action (intent : Intent) (args : intent.Args.type) (provided : List S
               { label := c.label,
                 appData := {
                   memberId := Class.Label.MemberId.intentId intentId,
-                  memberArgs := UUnit.unit,
-                  publicFields := c.consumed.object.publicFields }})
+                  memberArgs := UUnit.unit }})
 
 /-- A transaction which consumes the provided objects and creates the intent. -/
 def Intent.transaction (intent : Intent) (args : intent.Args.type) (provided : List SomeObject) (key : Anoma.NullifierKey) (currentRoot : Anoma.CommitmentRoot) : Option Anoma.Transaction := do

--- a/AVM/Object.lean
+++ b/AVM/Object.lean
@@ -12,8 +12,6 @@ structure Object (lab : Class.Label) where
   quantity : Nat
   /-- `privateFields` go into the `value` field of the resource -/
   privateFields : lab.PrivateFields.type
-  /-- `publicFields` go into the `appData` field of the action -/
-  publicFields : lab.PublicFields.type
   deriving BEq
 
 instance Object.hasTypeRep (lab : Class.Label) : TypeRep (Object lab) where
@@ -65,23 +63,18 @@ def Object.toResource {lab : Class.Label} (obj : Object lab) (ephemeral : Bool) 
 
 def Object.fromResource
   {lab : Class.Label}
-  (publicFields : lab.PublicFields.type)
   (res : Anoma.Resource)
   : Option (Object lab) := do
   let privateFields : lab.PrivateFields.type ← SomeType.cast res.value
   pure { quantity := res.quantity,
          nullifierKeyCommitment := res.nullifierKeyCommitment,
-         privateFields := privateFields,
-         publicFields := publicFields }
+         privateFields := privateFields }
 
 def SomeObject.fromResource
-  {PublicFields : SomeType}
-  (publicFields : PublicFields.type)
   (res : Anoma.Resource)
   : Option SomeObject := do
   let resLab : Object.Resource.Label ← tryCast res.label
   let lab : Class.Label := resLab.classLabel
-  let lab' := {lab with PublicFields := PublicFields}
-  match @Object.fromResource lab' publicFields res with
+  match @Object.fromResource lab res with
   | none => none
-  | some obj => pure {label := lab', object := obj}
+  | some obj => pure {label := lab, object := obj}

--- a/Apps/OwnedCounter.lean
+++ b/Apps/OwnedCounter.lean
@@ -31,7 +31,6 @@ open AVM
 def lab : Class.Label where
   name := "OwnedCounter"
   PrivateFields := ⟨Nat⟩
-  PublicFields := ⟨Unit⟩
   MethodId := Methods
   MethodArgs := fun
     | Methods.Incr => ⟨Nat⟩
@@ -42,7 +41,6 @@ def lab : Class.Label where
   DestructorId := Destructors
 
 def toObject (c : OwnedCounter) : Object lab where
-  publicFields := Unit.unit
   quantity := 1
   privateFields := c.count
   nullifierKeyCommitment := c.key

--- a/Apps/UniversalCounter.lean
+++ b/Apps/UniversalCounter.lean
@@ -24,7 +24,6 @@ open AVM
 def lab : Class.Label where
   name := "UniversalCounter"
   PrivateFields := ⟨Nat⟩
-  PublicFields := ⟨Unit⟩
 
   MethodId := Methods
   MethodArgs := fun
@@ -35,7 +34,6 @@ def lab : Class.Label where
     | Constructors.Zero => ⟨Unit⟩
 
 def toObject (c : Counter) : Object lab where
-  publicFields := Unit.unit
   quantity := 1
   privateFields := c.count
   nullifierKeyCommitment := none


### PR DESCRIPTION
This pr removes public fields from Object, Label and AppData.
In practice, we were never using public fields. In theory they were meant as an abstraction to add information into AppData. However, the information should be associated with each class member rather than the object itself.
Whether we need this abstraction is not entirely clear yet.