### PR TITLE
Computation of delta proofs in transactions

### DIFF
--- a/AVM/Class/Member/Logic.lean
+++ b/AVM/Class/Member/Logic.lean
@@ -4,18 +4,18 @@ import AVM.Class.Member
 
 namespace AVM.Class
 
-def dummyResource (nonce : Anoma.Nonce): Anoma.Resource :=
-  { Val := ⟨Unit⟩,
-    Label := ⟨String⟩,
-    label := "dummy-resource",
+def dummyResource (nonce : Anoma.Nonce) : Anoma.Resource.{u, v} :=
+  { Val := ⟨UUnit⟩,
+    Label := ⟨ULift String⟩,
+    label := ULift.up "dummy-resource",
     quantity := 0,
-    value := (),
+    value := UUnit.unit,
     ephemeral := true,
     nonce,
     nullifierKeyCommitment := Anoma.NullifierKeyCommitment.universal }
 
-def Member.Logic.filterOutDummy (resources : List Anoma.Resource) : List Anoma.Resource :=
-  resources.filter (fun res => res.label !== "dummy-resource")
+def Member.Logic.filterOutDummy (resources : List Anoma.Resource.{u, v}) : List Anoma.Resource.{u, v} :=
+  resources.filter (fun res => res.label !== ULift.up.{v} "dummy-resource")
 
 /-- Checks that the number of objects and resources match, and that the
     resources' private data and labels match the objects' private data and

--- a/Anoma/Compliance.lean
+++ b/Anoma/Compliance.lean
@@ -6,17 +6,17 @@ namespace Anoma
 
 abbrev MerklePath := List Nat
 
-structure ComplianceWitness where
-    consumedResource : Resource
-    createdResource : Resource
+structure ComplianceWitness : Type (max u v + 1) where
+    consumedResource : Resource.{u, v}
+    createdResource : Resource.{u, v}
     /-- Nullifier key of the consumed resource -/
     nfKey : NullifierKey
+    /-- Random scalar for delta commitment -/
+    rcv : String
     /-- The path from the consumed commitment to the root in the commitment tree -/
     merklePath : MerklePath := []
     /-- The existing root for the ephemeral resource -/
     ephemeralRoot : String := ""
-    /-- Random scalar for delta commitment -/
-    rcv : String := ""
 
 structure ComplianceInstance where
 

--- a/Anoma/Delta.lean
+++ b/Anoma/Delta.lean
@@ -1,0 +1,13 @@
+
+import Prelude
+import Anoma.Compliance
+
+namespace Anoma
+
+abbrev DeltaProof := String
+
+structure DeltaWitness : Type where
+  signingKey : String
+
+def DeltaWitness.fromComplianceWitnesses (witnesses : List ComplianceWitness) : DeltaWitness :=
+  { signingKey := witnesses.map ComplianceWitness.rcv |>.foldl (· ++ ·) "" }

--- a/Anoma/Resource.lean
+++ b/Anoma/Resource.lean
@@ -9,9 +9,9 @@ namespace Anoma
 /-- Representation of Anoma Resource data, without the resource logic. In the
     GOOSE model, the resource logic is determined by the `label` field (which
     contains the unique label of the class). -/
-structure Resource where
-  Val : SomeType
-  Label : SomeType
+structure Resource : Type (max u v + 1) where
+  Val : SomeType.{u}
+  Label : SomeType.{v}
   label : Label.type
   quantity : Nat
   value : Val.type

--- a/Anoma/Transaction.lean
+++ b/Anoma/Transaction.lean
@@ -1,10 +1,13 @@
 
 import Anoma.Action
+import Anoma.Delta
 
 namespace Anoma
-
-abbrev DeltaProof := String
 
 structure Transaction where
   actions : List Action
   deltaProof : DeltaProof
+
+def Transaction.generateDeltaProof (witness : DeltaWitness) (actions : List Action) : DeltaProof :=
+  -- Placeholder implementation for generating a delta proof
+  "DeltaProof for a transaction with " ++ toString (List.length actions) ++ " actions and signing key " ++ witness.signingKey


### PR DESCRIPTION
- Depends on #36 
- Closes #40 
- Adds mock functions to compute the `deltaProof` fields of Transactions, following the general strategy from RISC0 RM.
