### PR TITLE
Intent labels

### DIFF
--- a/AVM/Class.lean
+++ b/AVM/Class.lean
@@ -12,10 +12,14 @@ namespace AVM
 structure Class {lab : Ecosystem.Label} (classId : lab.ClassId) : Type (u + 1) where
   /-- The constructors of the class. -/
   constructors : (c : classId.label.ConstructorId) → Class.Constructor c
+  /-- The destructors of the class. -/
+  destructors : (d : classId.label.DestructorId) → Class.Destructor d
   /-- The methods of the class. -/
   methods : (m : classId.label.MethodId) → Class.Method m
-  /-- The destructors of the class. -/
-  destructors : (m : classId.label.DestructorId) → Class.Destructor m
+  /-- The intents allowed by the class. The intents are not uniquely associated
+      with a class. In contrast to constructors, destructors and methods, an
+      intent can be a member of multiple different classes. -/
+  intents : (l : Intent.Label) → l ∈ classId.label.intentLabels → Intent l
   /-- Extra class-specific logic. The whole resource logic function for an
     object consists of the class invariant and the member logics. -/
   invariant : (self : Object classId.label) → Logic.Args lab → Bool := fun _ _ => true

--- a/AVM/Ecosystem.lean
+++ b/AVM/Ecosystem.lean
@@ -7,7 +7,3 @@ namespace AVM
 structure Ecosystem (label : Ecosystem.Label) : Type (u + 1) where
   classes : (c : label.ClassId) → Class c
   functions : (f : label.FunctionId) → Function f
-  /-- The intents known by and allowed for the Ecosystem. The intents are not
-    uniquely associated with an ecosystem. In contrast to functions,
-    an intent can be a member of multiple different ecosystems. -/
-  intents : label.IntentId → Intent

--- a/AVM/Ecosystem/Label.lean
+++ b/AVM/Ecosystem/Label.lean
@@ -7,7 +7,8 @@ structure Label where
   name : String
 
   ClassId : Type
-  classes : ClassId -> Class.Label
+  classLabel : ClassId → Class.Label
+  classId : Class.Label → Option ClassId
   [classesFinite : Fintype ClassId]
   [classesRepr : Repr ClassId]
   [classesBEq : BEq ClassId]
@@ -32,15 +33,15 @@ def singleton (l : Class.Label) : Ecosystem.Label where
   name := l.name
 
   ClassId := UUnit
-  classes := fun _ => l
+  classLabel := fun _ => l
+  classId := fun l' => if l' == l then some UUnit.unit else none
 
   FunctionObjectArgClass := fun _ => UUnit.unit
   objectArgNamesEnum := fun f => f.elim
   objectArgNamesBEq := fun f => f.elim
 
-
 def ClassId.label {lab : Ecosystem.Label} (classId : lab.ClassId) : Class.Label :=
-  lab.classes classId
+  lab.classLabel classId
 
 def ClassId.MemberId {lab : Ecosystem.Label} (c : lab.ClassId) := c.label.MemberId
 

--- a/AVM/Ecosystem/Translation.lean
+++ b/AVM/Ecosystem/Translation.lean
@@ -9,35 +9,6 @@ namespace AVM.Ecosystem
 
 open AVM.Action
 
-/-- Creates a member logic for a given intent. This logic is checked when an
-  object is consumed to create the intent. Note that the intent member logic
-  (defined here) is distinct from the intent logic defined in
-  `AVM/Intent/Translation.lean`. The intent member logic is associated with
-  a resource consumed by the intent and it checks that the right intent is
-  created. The intent logic is checked on consumption of the intent resource
-  and it checks that the the intent's condition is satified. -/
-def Intent.logic
-  {lab : Ecosystem.Label}
-  (intent : Intent)
-  (args : Logic.Args lab)
-  : Bool :=
-  if args.isConsumed then
-    -- Check that exactly one resource is created that corresponds to the intent
-    match Logic.filterOutDummy args.created with
-    | [intentRes] => BoolCheck.run do
-      let labelData ← BoolCheck.some <| Intent.LabelData.fromResource intentRes
-      BoolCheck.ret <|
-        -- NOTE: We should also check that the intent logic hashes of
-        -- `intentRes` and `intent` match.
-        labelData.label === intent.label
-        && intentRes.quantity == 1
-        && intentRes.ephemeral
-        && Logic.checkResourceData labelData.data.provided args.consumed
-    | _ =>
-      false
-  else
-    true
-
 def Function.parseObjectArgs
   {lab : Ecosystem.Label}
   (args : Logic.Args lab)
@@ -124,7 +95,6 @@ private def logic'
   | Consumed =>
     match args.data with
     | {memberId := .falseLogicId, ..} => false
-    | {memberId := .intentId i, ..} => Intent.logic (eco.intents i) args
     | {memberId := .classMember mem, memberArgs} => Class.checkClassMemberLogic args eco mem memberArgs
     | {memberId := .functionId fn, memberArgs} => Function.logic eco args fn memberArgs
 

--- a/AVM/Intent/Label.lean
+++ b/AVM/Intent/Label.lean
@@ -1,0 +1,19 @@
+
+import Prelude
+
+namespace AVM
+
+structure Intent.Label where
+  /-- The type of intent arguments. The arguments are stored in the `value`
+    field of the intent resource. They are not provided in the app data for any
+    resource logics. -/
+  Args : SomeType
+  /-- The unique name of the intent. -/
+  name : String
+  deriving BEq
+
+instance Intent.Label.hasTypeRep : TypeRep Intent.Label where
+  rep := Rep.atomic "AVM.Intent.Label"
+
+instance Intent.Label.hasHashable : Hashable Intent.Label where
+  hash a := hash a.name

--- a/AVM/Intent/Translation.lean
+++ b/AVM/Intent/Translation.lean
@@ -92,9 +92,9 @@ def Intent.action'
 
       mkTagDataPairConsumed (c : SomeConsumedObject)
        : Option (Anoma.Tag × SomeAppData) :=
-          match label.classId c.label with
-          | none => none
-          | some classId =>
+        match label.classId c.label with
+        | none => none
+        | some classId =>
           some
             (Anoma.Tag.Consumed c.consumed.can_nullify.nullifier,
               { label := label,

--- a/AVM/Intent/Translation.lean
+++ b/AVM/Intent/Translation.lean
@@ -92,11 +92,14 @@ def Intent.action'
 
       mkTagDataPairConsumed (c : SomeConsumedObject)
        : Option (Anoma.Tag × SomeAppData) :=
+          match label.classId c.label with
+          | none => none
+          | some classId =>
           some
             (Anoma.Tag.Consumed c.consumed.can_nullify.nullifier,
               { label := label,
                 appData := {
-                  memberId := .classMember (classId := c.label) (Class.Label.MemberId.intentId ilab),
+                  memberId := .classMember (classId := classId) (Class.Label.MemberId.intentId ilab),
                   memberArgs := UUnit.unit }})
 
 /-- An action which consumes the provided objects and creates the intent. -/

--- a/Applib.lean
+++ b/Applib.lean
@@ -4,8 +4,7 @@ namespace Applib
 
 open AVM
 
-def noIntents {A : Type u} : Empty -> A := Empty.elim
-
+macro "noIntents" lab:ident clab:ident : term => `(fun _ h => by simp [$lab:ident, Ecosystem.Label.ClassId.label, Ecosystem.Label.singleton, $clab:ident] at h)
 macro "noDestructors" : term => `(fun x => Empty.elim x)
 macro "noFunctions" : term => `(fun x => Empty.elim x)
 macro "noMethods" : term => `(fun x => Empty.elim x)
@@ -55,4 +54,3 @@ def defDestructor {cl : Type} [i : IsObject cl] {destructorId : i.lab.Destructor
     match i.fromObject self with
     | none => false
     | some self' => invariant self' args
-

--- a/Apps/OwnedCounter.lean
+++ b/Apps/OwnedCounter.lean
@@ -39,6 +39,7 @@ def clab : Class.Label where
   ConstructorArgs := fun
     | Constructors.Zero => ⟨Unit⟩
   DestructorId := Destructors
+  intentLabels := ∅
 
 def lab : Ecosystem.Label := Ecosystem.Label.singleton clab
 
@@ -86,8 +87,8 @@ def counterClass : @Class lab .unit where
     | Methods.Transfer => counterTransfer
   destructors := fun
     | Destructors.Ten => counterDestroy
+  intents := noIntents lab clab
 
 def counterEcosystem : Ecosystem lab where
   classes := fun _ => counterClass
-  intents := noIntents
   functions := noFunctions

--- a/Apps/UniversalCounter.lean
+++ b/Apps/UniversalCounter.lean
@@ -33,6 +33,8 @@ def clab : Class.Label where
   ConstructorArgs := fun
     | Constructors.Zero => ⟨Unit⟩
 
+  intentLabels := ∅
+
 def lab : Ecosystem.Label := Ecosystem.Label.singleton clab
 
 def toObject (c : Counter) : Object clab where
@@ -68,8 +70,8 @@ def counterClass : @Class lab UUnit.unit where
   methods := fun
     | Methods.Incr => counterIncr
   destructors := noDestructors
+  intents := noIntents lab clab
 
 def counterEcosystem : Ecosystem lab where
   classes := fun _ => counterClass
-  intents := noIntents
   functions := noFunctions


### PR DESCRIPTION
- Closes #48 
- Adds global Intent.Label to replace the ecosystem-local intent ids.
- Now each class label has a set of allowed intent labels.
