### PR TITLE
Fix computation of nonces

### DIFF
--- a/AVM/Class/Translation.lean
+++ b/AVM/Class/Translation.lean
@@ -46,8 +46,7 @@ def Constructor.action
         key := Anoma.NullifierKey.universal }
   let consumed : ConsumedObject classId.label := { consumable with can_nullify := Anoma.nullifyUniversal consumable.resource consumable.key rfl rfl }
   let created : List CreatedObject :=
-        [CreatedObject.fromSomeObject newObj.toSomeObject (ephemeral := false)
-          (nonce := consumed.can_nullify.nullifier.toNonce)]
+        [CreatedObject.fromSomeObject newObj.toSomeObject (ephemeral := false)]
   Action.create lab (.classMember (.constructorId constrId)) args [consumed] created
 
 /-- Creates an Anoma Transaction for a given object construtor. -/
@@ -87,18 +86,14 @@ def Method.action
   (key : Anoma.NullifierKey)
   (args : methodId.Args.type)
   : Rand (Option (Anoma.Action × Anoma.DeltaWitness)) := do
-  -- TODO: set nonce and nullifierKeyCommitment properly
   let consumable : ConsumableObject classId.label :=
       { key
         object := self
         ephemeral := false }
   let try consumed := consumable.consume
   let createObject (o : SomeObject) : CreatedObject :=
-    -- FIXME see https://github.com/anoma/goose-lean/issues/51
-    let res : Anoma.Resource := o.toResource (ephemeral := false) (nonce := consumed.can_nullify.nullifier.toNonce)
     { object := o.object
-      resource := res
-      commitment := res.commitment }
+      ephemeral := false }
   let created : List CreatedObject :=
       List.map createObject (method.created self args)
   Action.create lab (.classMember (.methodId methodId)) args [consumed] created
@@ -148,10 +143,8 @@ def Destructor.action
          ephemeral := false }
   let try consumed := consumable.consume
   let createdObject : CreatedObject :=
-    let ephResource := { consumed.resource with ephemeral := true }
     { object := self
-      resource := ephResource
-      commitment := ephResource.commitment }
+      ephemeral := true }
   Action.create lab (.classMember (.destructorId destructorId)) args [consumed] [createdObject]
 
 /-- Creates an Anoma Transaction for a given object destructor. -/

--- a/AVM/Ecosystem/Translation.lean
+++ b/AVM/Ecosystem/Translation.lean
@@ -68,8 +68,7 @@ def Function.action
       |> SomeConsumableObject.consume)
     |>.getSome
   let createdObjects : List CreatedObject := fn.created consumedObjects fargs |>
-      List.map (fun x => CreatedObject.fromSomeObject x (ephemeral := false)
-        (nonce := Anoma.Nonce.todo)) -- FIXME the Nonce.todo should be replaced with the fix of https://github.com/anoma/goose-lean/issues/51
+      List.map (fun x => CreatedObject.fromSomeObject x (ephemeral := false))
   let r ← Action.create lab (.functionId funId) fargs consumedList createdObjects
   pure (some r)
 

--- a/AVM/Intent.lean
+++ b/AVM/Intent.lean
@@ -37,7 +37,7 @@ structure Intent.LabelData : Type (u + 1) where
 instance Intent.LabelData.hasTypeRep : TypeRep Intent.LabelData where
   rep := Rep.atomic "AVM.Intent.LabelData"
 
-def Intent.toResource {ilab : Intent.Label} (_intent : Intent ilab) (args : ilab.Args.type) (provided : List SomeObject) (nonce : Anoma.Nonce := default) (nullifierKeyCommitment : Anoma.NullifierKeyCommitment := default) : Anoma.Resource :=
+def Intent.toResource {ilab : Intent.Label} (_intent : Intent ilab) (args : ilab.Args.type) (provided : List SomeObject) (nonce : Anoma.Nonce) (nullifierKeyCommitment : Anoma.NullifierKeyCommitment := default) : Anoma.Resource :=
   { Val := ⟨Unit⟩,
     Label := ⟨Intent.LabelData⟩,
     label := {

--- a/AVM/Intent/Translation.lean
+++ b/AVM/Intent/Translation.lean
@@ -45,7 +45,6 @@ def Intent.action'
   (provided : List SomeObject)
   (key : Anoma.NullifierKey)
   : Option (Anoma.Action × Anoma.DeltaWitness) × StdGen :=
-  let intentResource := Intent.toResource intent args provided
   let try providedConsumed :=
         provided.map (fun p => p.toConsumable false key |>.consume) |>.getSome
       failwith (none, g)
@@ -59,13 +58,15 @@ def Intent.action'
     providedConsumed.foldr mkConsumedComplianceWitness ([], g)
   let consumedUnits : List Anoma.ComplianceUnit :=
     consumedWitnesses.map Anoma.ComplianceUnit.create
-  let (r, g2) := stdNext g1
-  let (r', g3) := stdNext g2
+  let (r1, g2) := stdNext g1
+  let (r2, g3) := stdNext g2
+  let (r3, g4) := stdNext g3
+  let intentResource : Anoma.Resource := Intent.toResource intent args provided (nonce := ⟨r3⟩)
   let createdWitness : Anoma.ComplianceWitness :=
-    { consumedResource := dummyResource ⟨r⟩,
+    { consumedResource := dummyResource ⟨r1⟩,
       createdResource := intentResource,
       nfKey := key,
-      rcv := r'.repr }
+      rcv := r2.repr }
   let createdUnit : Anoma.ComplianceUnit :=
     Anoma.ComplianceUnit.create createdWitness
   let action :=
@@ -73,7 +74,7 @@ def Intent.action'
         logicVerifierInputs }
   let witness : Anoma.DeltaWitness :=
     Anoma.DeltaWitness.fromComplianceWitnesses (consumedWitnesses ++ [createdWitness])
-  (some (action, witness), g3)
+  (some (action, witness), g4)
 where
   mkConsumedComplianceWitness (obj : SomeConsumedObject) : List Anoma.ComplianceWitness × StdGen → List Anoma.ComplianceWitness × StdGen
     | (acc, g) =>


### PR DESCRIPTION
- Closes #51 
- Closes #49 

Nonce computation:
- For consumed persistent resources the nonce must be available in the object.
- For consumed ephemeral resources the nonce is random.
- For created resources (persistent and ephemeral) the nonce is equal to the nullifier of the consumed resource in the same compliance unit.
