### PR TITLE
Syntax with binders for Applib Programs

### DIFF
--- a/AVM/Task/Translation.lean
+++ b/AVM/Task/Translation.lean
@@ -21,7 +21,7 @@ private def resolveParameters (params : Task.Parameters) (cont : params.Product 
   | .fetch p ps =>
     Anoma.Program.queryResource (Anoma.Program.ResourceQuery.queryByObjectId p.uid) (fun res =>
       let try obj : Object p.classLabel := Object.fromResource res
-          failwith Anoma.Program.raise <| Anoma.Program.Error.typeError ("expected object of class " ++ p.classLabel.name);
+          failwith Anoma.Program.raise <| Anoma.Program.Error.typeError ("expected object of class " ++ p.classLabel.name)
       resolveParameters (ps obj) (fun vals => cont ⟨obj, vals⟩))
   | .genId ps =>
     Anoma.Program.genObjectId (fun objId =>

--- a/Applib/Surface.lean
+++ b/Applib/Surface.lean
@@ -1,4 +1,5 @@
 import Applib.Surface.Object
 import Applib.Surface.Reference
 import Applib.Surface.Program
+import Applib.Surface.Program.Syntax
 import Applib.Surface.Member

--- a/Applib/Surface/Member.lean
+++ b/Applib/Surface/Member.lean
@@ -30,7 +30,7 @@ def defConstructor {cl : Type} [i : IsObject cl] {constrId : i.classId.label.Con
     body (args : constrId.Args.type) := body args |>.map i.toObject |>.toBody
 
 def defDestructor {cl : Type} [i : IsObject cl] {destructorId : i.classId.label.DestructorId}
- (body : (self : cl) → destructorId.Args.type → Program i.label PUnit)
+ (body : (self : cl) → destructorId.Args.type → Program i.label PUnit := fun _ _ => Program.return fun _ => ())
  (invariant : (self : cl) -> destructorId.Args.type → Bool := fun _ _ => true)
  : Class.Destructor i.classId destructorId where
     invariant (self : Object i.classId.label) (args : destructorId.Args.type) :=

--- a/Applib/Surface/Program.lean
+++ b/Applib/Surface/Program.lean
@@ -143,11 +143,11 @@ alias Program.callById := Program'.call
 alias Program.fetchById := Program'.fetch
 alias Program.return := Program'.return
 
-def Program.destroy {params ReturnType} (C : Type) (r : params.Product → Reference C) [i : IsObject C] (destrId : i.classId.label.DestructorId) (args : params.Product → destrId.Args.type) (next : Program' i.label ReturnType params) : Program' i.label ReturnType params :=
+def Program.destroy {params ReturnType} (C : Type) [i : IsObject C] (destrId : i.classId.label.DestructorId) (r : params.Product → Reference C) (args : params.Product → destrId.Args.type) (next : Program' i.label ReturnType params) : Program' i.label ReturnType params :=
   Program.destroyById i.classId destrId (fun vals => (r vals).objId) args next
 
-def Program.call {params ReturnType} {C : Type} (r : params.Product → Reference C) [i : IsObject C] (methodId : i.classId.label.MethodId) (args : params.Product → methodId.Args.type) (next : Program' i.label ReturnType params) : Program' i.label ReturnType params :=
+def Program.call {params ReturnType} (C : Type) [i : IsObject C] (methodId : i.classId.label.MethodId) (r : params.Product → Reference C) (args : params.Product → methodId.Args.type) (next : Program' i.label ReturnType params) : Program' i.label ReturnType params :=
   Program.callById i.classId methodId (fun vals => (r vals).objId) args next
 
-def Program.fetch {params ReturnType} {lab : Ecosystem.Label} {C : Type} (r : params.Product → Reference C) [i : IsObject C] (next : Program' lab ReturnType (Program.Parameters.snocFetch C params (fun vals => (r vals).objId))) : Program' lab ReturnType params :=
+def Program.fetch {params ReturnType} {lab : Ecosystem.Label} {C : Type} (r : params.Product → Reference C) [i : IsObject C] (next : Program' lab ReturnType (params.snocFetch C (fun vals => (r vals).objId))) : Program' lab ReturnType params :=
   Program.fetchById C (fun vals => (r vals).objId) next

--- a/Applib/Surface/Program.lean
+++ b/Applib/Surface/Program.lean
@@ -9,13 +9,13 @@ open AVM
 inductive Program.Parameters where
   | empty
   | fetch (C : Type) (i : IsObject C) (param : ObjectId) (rest : C → Program.Parameters)
-  | genId (rest : ObjectId → Program.Parameters)
+  | genRef (C : Type) (rest : Reference C → Program.Parameters)
 deriving Inhabited
 
 def Program.Parameters.Product : Program.Parameters → Type
   | .empty => Unit
   | .fetch C _ _ rest => Σ (c : C), (rest c).Product
-  | .genId rest => Σ (id : ObjectId), (rest id).Product
+  | .genRef C rest => Σ (ref : Reference C), (rest ref).Product
 
 def Program.Parameters.append (params1 : Program.Parameters) (params2 : params1.Product → Program.Parameters) : Program.Parameters :=
   match params1 with
@@ -27,19 +27,19 @@ def Program.Parameters.append (params1 : Program.Parameters) (params2 : params1.
         (ps1 obj).append
           (fun vals =>
             params2 ⟨obj, vals⟩))
-  | .genId ps1 =>
-    .genId (fun objId => (ps1 objId).append (fun vals => params2 ⟨objId, vals⟩))
+  | .genRef C ps1 =>
+    .genRef C (fun ref => (ps1 ref).append (fun vals => params2 ⟨ref, vals⟩))
 
 def Program.Parameters.snocFetch (C : Type) [i : IsObject C] (params : Program.Parameters) (objId : params.Product → ObjectId) : Program.Parameters :=
   params.append (fun vals => .fetch C i (objId vals) (fun _ => .empty))
 
-def Program.Parameters.snocGenId (params : Program.Parameters) : Program.Parameters :=
-  params.append (fun _ => .genId (fun _ => .empty))
+def Program.Parameters.snocGenId (C : Type) (params : Program.Parameters) : Program.Parameters :=
+  params.append (fun _ => .genRef C (fun _ => .empty))
 
 def Program.Parameters.toTaskParameters : Program.Parameters → Task.Parameters
   | .empty => .empty
   | .fetch _ i p rest => .fetch ⟨i.classId.label, p⟩ (fun obj => toTaskParameters (rest (i.fromObject obj.data)))
-  | .genId rest => .genId (fun id => toTaskParameters (rest id))
+  | .genRef _ rest => .genId (fun id => toTaskParameters (rest ⟨id⟩))
 
 def Task.Parameters.Values.toProgramParameterValues {params : Program.Parameters} (vals : params.toTaskParameters.Product) : params.Product :=
   match params with
@@ -47,15 +47,15 @@ def Task.Parameters.Values.toProgramParameterValues {params : Program.Parameters
   | .fetch _ i _ _ =>
     let ⟨obj, vals'⟩ := vals
     ⟨i.fromObject obj.data, toProgramParameterValues vals'⟩
-  | .genId _ =>
+  | .genRef _ _ =>
     let ⟨objId, vals'⟩ := vals
-    ⟨objId, toProgramParameterValues vals'⟩
+    ⟨⟨objId⟩, toProgramParameterValues vals'⟩
 
-lemma Program.Parameters.toTaskParameters_genId {params : Program.Parameters} :
-  params.snocGenId.toTaskParameters = params.toTaskParameters.snocGenId := by
+lemma Program.Parameters.toTaskParameters_genId {params : Program.Parameters} (C : Type) :
+  (params.snocGenId C).toTaskParameters = params.toTaskParameters.snocGenId := by
   induction params <;> simp [Program.Parameters.snocGenId, Program.Parameters.toTaskParameters, Program.Parameters.append]
-  case fetch C i p1 ps1 ih => congr; funext; apply ih
-  case genId ps1 ih => congr; funext; apply ih
+  case fetch C' i p1 ps1 ih => congr; funext; apply ih
+  case genRef C' ps1 ih => congr; funext; apply ih
   case empty => rfl
 
 lemma Program.Parameters.toTaskParameters_snocFetch (C : Type) [i : IsObject C] {params : Program.Parameters} (objId : params.Product → ObjectId) :
@@ -63,16 +63,17 @@ lemma Program.Parameters.toTaskParameters_snocFetch (C : Type) [i : IsObject C] 
     params.toTaskParameters.snocFetch (fun vals => ⟨i.classId.label, objId (Task.Parameters.Values.toProgramParameterValues vals)⟩) := by
   induction params <;> simp [Program.Parameters.snocFetch, Program.Parameters.toTaskParameters, Program.Parameters.append]
   case fetch C' i' p1 ps1 ih => congr; funext; apply ih
-  case genId ps1 ih => congr; funext; apply ih
+  case genRef C' ps1 ih => congr; funext; apply ih
   case empty => rfl
 
 inductive Program' (lab : Ecosystem.Label) (ReturnType : Type) : Program.Parameters → Type 2 where
   | create
       {params : Program.Parameters}
+      (C : Type)
       (cid : lab.ClassId)
       (constrId : cid.label.ConstructorId)
       (args : params.Product → constrId.Args.type)
-      (next : Program' lab ReturnType params.snocGenId)
+      (next : Program' lab ReturnType (params.snocGenId C))
       : Program' lab ReturnType params
   | destroy
       {params : Program.Parameters}
@@ -104,7 +105,7 @@ inductive Program' (lab : Ecosystem.Label) (ReturnType : Type) : Program.Paramet
 
 def Program'.toBody {lab ReturnType params} (prog : Program' lab ReturnType params) : Class.Member.Body lab ReturnType params.toTaskParameters :=
   match prog with
-  | .create cid constrId args next =>
+  | .create C cid constrId args next =>
     let next' := cast (by rw [Program.Parameters.toTaskParameters_genId]) (toBody next)
     .constructor cid constrId (convertFun args) next'
   | .destroy cid destrId selfId args next =>
@@ -122,8 +123,8 @@ def Program'.toBody {lab ReturnType params} (prog : Program' lab ReturnType para
 
 def Program'.map {lab : Ecosystem.Label} {A B : Type} {params : Program.Parameters} (f : A → B) (prog : Program' lab A params) : Program' lab B params :=
   match prog with
-  | .create cid constrId args next =>
-    .create cid constrId args (map f next)
+  | .create C cid constrId args next =>
+    .create C cid constrId args (map f next)
   | .destroy cid destrId selfId args next =>
     .destroy cid destrId selfId args (map f next)
   | .call cid methodId selfId args next =>
@@ -137,11 +138,14 @@ def Program (lab : Ecosystem.Label) (Result : Type) := Program' lab Result .empt
 
 def Program.map {lab : Ecosystem.Label} {A B : Type} (f : A → B) (prog : Program lab A) : Program lab B := Program'.map f prog
 
-alias Program.create := Program'.create
+alias Program.createById := Program'.create
 alias Program.destroyById := Program'.destroy
 alias Program.callById := Program'.call
 alias Program.fetchById := Program'.fetch
 alias Program.return := Program'.return
+
+def Program.create {params ReturnType} (C : Type) [i : IsObject C] (constrId : i.classId.label.ConstructorId) (args : params.Product → constrId.Args.type) (next : Program' i.label ReturnType (params.snocGenId C)) : Program' i.label ReturnType params :=
+  Program.createById C i.classId constrId args next
 
 def Program.destroy {params ReturnType} (C : Type) [i : IsObject C] (destrId : i.classId.label.DestructorId) (r : params.Product → Reference C) (args : params.Product → destrId.Args.type) (next : Program' i.label ReturnType params) : Program' i.label ReturnType params :=
   Program.destroyById i.classId destrId (fun vals => (r vals).objId) args next

--- a/Applib/Surface/Program.lean
+++ b/Applib/Surface/Program.lean
@@ -143,13 +143,11 @@ alias Program.callById := Program'.call
 alias Program.fetchById := Program'.fetch
 alias Program.return := Program'.return
 
-def Program.destroy {params ReturnType} (C : Type) [i : IsObject C] (destrId : i.classId.label.DestructorId) (r : params.Product → Reference C) (args : params.Product → destrId.Args.type) (next : Program' i.label ReturnType params) : Program' i.label ReturnType params :=
+def Program.destroy {params ReturnType} (C : Type) (r : params.Product → Reference C) [i : IsObject C] (destrId : i.classId.label.DestructorId) (args : params.Product → destrId.Args.type) (next : Program' i.label ReturnType params) : Program' i.label ReturnType params :=
   Program.destroyById i.classId destrId (fun vals => (r vals).objId) args next
 
-def Program.call {params ReturnType} (C : Type) [i : IsObject C] (methodId : i.classId.label.MethodId) (r : params.Product → Reference C) (args : params.Product → methodId.Args.type) (next : Program' i.label ReturnType params) : Program' i.label ReturnType params :=
+def Program.call {params ReturnType} {C : Type} (r : params.Product → Reference C) [i : IsObject C] (methodId : i.classId.label.MethodId) (args : params.Product → methodId.Args.type) (next : Program' i.label ReturnType params) : Program' i.label ReturnType params :=
   Program.callById i.classId methodId (fun vals => (r vals).objId) args next
 
-def Program.fetch {params ReturnType} {lab : Ecosystem.Label} {C : Type} [i : IsObject C] (r : params.Product → Reference C) (next : Program' lab ReturnType (Program.Parameters.snocFetch C params (fun vals => (r vals).objId))) : Program' lab ReturnType params :=
+def Program.fetch {params ReturnType} {lab : Ecosystem.Label} {C : Type} (r : params.Product → Reference C) [i : IsObject C] (next : Program' lab ReturnType (Program.Parameters.snocFetch C params (fun vals => (r vals).objId))) : Program' lab ReturnType params :=
   Program.fetchById C (fun vals => (r vals).objId) next
-
-end Applib

--- a/Applib/Surface/Program.lean
+++ b/Applib/Surface/Program.lean
@@ -138,20 +138,16 @@ def Program (lab : Ecosystem.Label) (Result : Type) := Program' lab Result .empt
 
 def Program.map {lab : Ecosystem.Label} {A B : Type} (f : A → B) (prog : Program lab A) : Program lab B := Program'.map f prog
 
-alias Program.createById := Program'.create
-alias Program.destroyById := Program'.destroy
-alias Program.callById := Program'.call
-alias Program.fetchById := Program'.fetch
-alias Program.return := Program'.return
-
 def Program.create {params ReturnType} (C : Type) [i : IsObject C] (constrId : i.classId.label.ConstructorId) (args : params.Product → constrId.Args.type) (next : Program' i.label ReturnType (params.snocGenId C)) : Program' i.label ReturnType params :=
-  Program.createById C i.classId constrId args next
+  Program'.create C i.classId constrId args next
 
 def Program.destroy {params ReturnType} (C : Type) [i : IsObject C] (destrId : i.classId.label.DestructorId) (r : params.Product → Reference C) (args : params.Product → destrId.Args.type) (next : Program' i.label ReturnType params) : Program' i.label ReturnType params :=
-  Program.destroyById i.classId destrId (fun vals => (r vals).objId) args next
+  Program'.destroy i.classId destrId (fun vals => (r vals).objId) args next
 
 def Program.call {params ReturnType} (C : Type) [i : IsObject C] (methodId : i.classId.label.MethodId) (r : params.Product → Reference C) (args : params.Product → methodId.Args.type) (next : Program' i.label ReturnType params) : Program' i.label ReturnType params :=
-  Program.callById i.classId methodId (fun vals => (r vals).objId) args next
+  Program'.call i.classId methodId (fun vals => (r vals).objId) args next
 
 def Program.fetch {params ReturnType} {lab : Ecosystem.Label} {C : Type} (r : params.Product → Reference C) [i : IsObject C] (next : Program' lab ReturnType (params.snocFetch C (fun vals => (r vals).objId))) : Program' lab ReturnType params :=
-  Program.fetchById C (fun vals => (r vals).objId) next
+  Program'.fetch C (fun vals => (r vals).objId) next
+
+alias Program.return := Program'.return

--- a/Applib/Surface/Program/Syntax.lean
+++ b/Applib/Surface/Program/Syntax.lean
@@ -1,0 +1,37 @@
+import Applib.Surface.Program
+import Apps.TwoCounter
+
+namespace Applib
+
+open Lean
+
+declare_syntax_cat program
+
+syntax "Ξ " ident* " . " program:40 : program
+syntax withPosition("set " ident " := " " fetch " term) optSemicolon(program) : program
+syntax withPosition("call " ident term) optSemicolon(program) : program
+syntax "return " term : program
+syntax (name := term_of_program) "⟪" program "⟫" : term
+
+def mkProducts {m} [Monad m] [MonadQuotation m] (ss : TSyntaxArray `ident) : m (TSyntax `term) := do
+  let unit : TSyntax `term ← `(_)
+  ss.foldrM (fun s acc => `(⟨$s, $acc⟩)) unit
+
+macro_rules
+  | `(⟪Ξ $ss:ident* . set $x:ident := fetch $e:term ; $p:program⟫) => do
+    let ps ← mkProducts ss
+    let stx ← `(Program.fetch (fun $ps => $e) (⟪Ξ $ss* $x . $p⟫))
+    dbg_trace Syntax.prettyPrint stx
+    return stx
+  | `(⟪Ξ $ss:ident* . return $e:term⟫) => do
+    let stx ← `(Program.return (fun $ss* => $e))
+    dbg_trace Syntax.prettyPrint stx
+    return stx
+
+open TwoCounterApp
+
+def counterRef : Reference Counter := ⟨42⟩
+
+-- set_option trace.Elab.step true
+
+#check ⟪Ξ . set x := fetch counterRef; return x⟫

--- a/Applib/Surface/Program/Syntax.lean
+++ b/Applib/Surface/Program/Syntax.lean
@@ -6,6 +6,7 @@ open Lean
 
 declare_syntax_cat program
 
+syntax withPosition("create " ident ident term) optSemicolon(program) : program
 syntax withPosition(ident " := " " create " ident ident term) optSemicolon(program) : program
 syntax withPosition("destroy " ident ident term) optSemicolon(program) : program
 syntax withPosition("call " ident ident term) optSemicolon(program) : program
@@ -20,6 +21,9 @@ def mkProducts {m} [Monad m] [MonadQuotation m] (ss : TSyntaxArray `ident) : m (
 
 macro_rules
   | `(⟪$p:program⟫) => `(Ξ . $p)
+  | `(Ξ $ss:ident* . create $c:ident $m:ident $e:term ; $p:program) => do
+    let ps ← mkProducts ss
+    `(Program.create $c $m (fun $ps => $e) (Ξ $ss* __ . $p))
   | `(Ξ $ss:ident* . $x:ident := create $c:ident $m:ident $e:term ; $p:program) => do
     let ps ← mkProducts ss
     `(Program.create $c $m (fun $ps => $e) (Ξ $ss* $x . $p))

--- a/Applib/Surface/Program/Syntax.lean
+++ b/Applib/Surface/Program/Syntax.lean
@@ -6,7 +6,7 @@ open Lean
 
 declare_syntax_cat program
 
-syntax withPosition(ident " := " " create " ident term) optSemicolon(program) : program
+syntax withPosition(ident " := " " create " ident ident term) optSemicolon(program) : program
 syntax withPosition("destroy " ident ident term) optSemicolon(program) : program
 syntax withPosition("call " ident ident term) optSemicolon(program) : program
 syntax withPosition(ident " := " " fetch " term) optSemicolon(program) : program
@@ -23,9 +23,9 @@ macro_rules
     let stx ← `(Ξ . $p)
     dbg_trace Syntax.prettyPrint stx
     return stx
-  | `(Ξ $ss:ident* . $x:ident := create $c:ident $e:term ; $p:program) => do
+  | `(Ξ $ss:ident* . $x:ident := create $c:ident $m:ident $e:term ; $p:program) => do
     let ps ← mkProducts ss
-    let stx ← `(Program.create $c (fun $ps => $e) (Ξ $ss* $x . $p))
+    let stx ← `(Program.create $c $m (fun $ps => $e) (Ξ $ss* $x . $p))
     dbg_trace Syntax.prettyPrint stx
     return stx
   | `(Ξ $ss:ident* . destroy $c:ident $m:ident $e:term $args:term ; $p:program) => do

--- a/Applib/Surface/Program/Syntax.lean
+++ b/Applib/Surface/Program/Syntax.lean
@@ -19,32 +19,19 @@ def mkProducts {m} [Monad m] [MonadQuotation m] (ss : TSyntaxArray `ident) : m (
   ss.foldrM (fun s acc => `(⟨$s, $acc⟩)) unit
 
 macro_rules
-  | `(⟪$p:program⟫) => do
-    let stx ← `(Ξ . $p)
-    dbg_trace Syntax.prettyPrint stx
-    return stx
+  | `(⟪$p:program⟫) => `(Ξ . $p)
   | `(Ξ $ss:ident* . $x:ident := create $c:ident $m:ident $e:term ; $p:program) => do
     let ps ← mkProducts ss
-    let stx ← `(Program.create $c $m (fun $ps => $e) (Ξ $ss* $x . $p))
-    dbg_trace Syntax.prettyPrint stx
-    return stx
+    `(Program.create $c $m (fun $ps => $e) (Ξ $ss* $x . $p))
   | `(Ξ $ss:ident* . destroy $c:ident $m:ident $e:term $args:term ; $p:program) => do
     let ps ← mkProducts ss
-    let stx ← `(Program.destroy $c $m (fun $ps => $e) (fun $ps => $args) (Ξ $ss* . $p))
-    dbg_trace Syntax.prettyPrint stx
-    return stx
+    `(Program.destroy $c $m (fun $ps => $e) (fun $ps => $args) (Ξ $ss* . $p))
   | `(Ξ $ss:ident* . call $c:ident $m:ident $e:term $args:term ; $p:program) => do
     let ps ← mkProducts ss
-    let stx ← `(Program.call $c $m (fun $ps => $e) (fun $ps => $args) (Ξ $ss* . $p))
-    dbg_trace Syntax.prettyPrint stx
-    return stx
+    `(Program.call $c $m (fun $ps => $e) (fun $ps => $args) (Ξ $ss* . $p))
   | `(Ξ $ss:ident* . $x:ident := fetch $e:term ; $p:program) => do
     let ps ← mkProducts ss
-    let stx ← `(Program.fetch (fun $ps => $e) (Ξ $ss* $x . $p))
-    dbg_trace Syntax.prettyPrint stx
-    return stx
+    `(Program.fetch (fun $ps => $e) (Ξ $ss* $x . $p))
   | `(Ξ $ss:ident* . return $e:term) => do
     let ps ← mkProducts ss
-    let stx ← `(Program.return (fun $ps => $e))
-    dbg_trace Syntax.prettyPrint stx
-    return stx
+    `(Program.return (fun $ps => $e))

--- a/Apps/Kudos.lean
+++ b/Apps/Kudos.lean
@@ -104,19 +104,19 @@ instance hasIsObject : IsObject Kudos where
   fromObject := Kudos.fromObject
 
 def kudosMint : @Class.Constructor label Classes.Kudos Constructors.Mint := defConstructor
-  (body := fun (args : MintArgs) =>
-    Program.return fun _ =>
+  (body := fun (args : MintArgs) => ⟪
+    return
       { quantity := args.quantity
         owner := args.originator
-        originator := args.originator : Kudos})
+        originator := args.originator : Kudos}
+  ⟫)
   (invariant := fun (args : MintArgs) => checkKey args.originator args.key)
 
 def kudosTransfer : @Class.Method label Classes.Kudos Methods.Transfer := defMethod Kudos
   (body := fun (self : Kudos) (args : TransferArgs) =>
-    Program.return fun _ => {self with owner := args.newOwner : Kudos})
+    ⟪return {self with owner := args.newOwner : Kudos}⟫)
 
 def kudosBurn : @Class.Destructor label Classes.Kudos Destructors.Burn := defDestructor
-  (body := fun (_ : Kudos) (_ : PUnit) => Program.return fun _ => ())
   (invariant := fun (self : Kudos) (_args : PUnit) => self.originator == self.owner)
 
 def kudosClass : @Class label Classes.Kudos where

--- a/Apps/KudosBank.lean
+++ b/Apps/KudosBank.lean
@@ -277,37 +277,39 @@ instance instIsObject : IsObject KudosBank where
 end KudosBank
 
 def kudosNew : @Class.Constructor label Classes.Bank Constructors.Open := defConstructor
-  (body := fun (owner : PublicKey) => Program.return fun _ => KudosBank.new owner)
+  (body := fun (owner : PublicKey) => ⟪return KudosBank.new owner⟫)
 
 def kudosMint : @Class.Method label Classes.Bank Methods.Mint := defMethod KudosBank
-  (body := fun (self : KudosBank) (args : MintArgs) =>
-    Program.return fun _ =>
-      self.overBalances (fun b => b.addTokens args.denom.originator args.denom args.quantity))
+  (body := fun (self : KudosBank) (args : MintArgs) => ⟪
+    return
+      self.overBalances (fun b => b.addTokens args.denom.originator args.denom args.quantity)
+  ⟫)
   (invariant := fun (_self : KudosBank) (args : MintArgs) => checkKey args.denom.originator args.key)
 
 def kudosTransfer : @Class.Method label Classes.Bank Methods.Transfer := defMethod KudosBank
-  (body := fun (self : KudosBank) (args : TransferArgs) =>
-    Program.return fun _ =>
+  (body := fun (self : KudosBank) (args : TransferArgs) => ⟪
+    return
       self.overBalances (fun b => b
         |> Balances.addTokens args.newOwner args.denom args.quantity
-        |> Balances.subTokens args.oldOwner args.denom args.quantity))
+        |> Balances.subTokens args.oldOwner args.denom args.quantity)
+  ⟫)
   (invariant := fun (self : KudosBank) (args : TransferArgs) =>
     checkKey args.oldOwner args.key
     && 0 < args.quantity
     && args.quantity <= self.getBalance args.oldOwner args.denom)
 
 def kudosBurn : @Class.Method label Classes.Bank Methods.Burn := defMethod KudosBank
-  (body := fun (self : KudosBank) (args : BurnArgs) =>
-    Program.return fun _ =>
+  (body := fun (self : KudosBank) (args : BurnArgs) => ⟪
+    return
       self.overBalances (fun b => b
-        |> Balances.subTokens args.denom.originator args.denom args.quantity))
+        |> Balances.subTokens args.denom.originator args.denom args.quantity)
+  ⟫)
   (invariant := fun (self : KudosBank) (args : BurnArgs) =>
     checkKey args.denom.originator args.key
     && 0 < args.quantity
     && args.quantity <= self.getBalance args.denom.originator args.denom)
 
 def kudosClose : @Class.Destructor label Classes.Bank Destructors.Close := defDestructor
-  (body := fun (_ : KudosBank) (_ : PUnit) => Program.return fun _ => ())
   (invariant := fun (self : KudosBank) (_args : PUnit) => self.balances.isEmpty)
 
 def kudosClass : @Class label Classes.Bank where
@@ -321,9 +323,10 @@ def kudosClass : @Class label Classes.Bank where
     | .Close => kudosClose
 
 def checkTransfer : @Class.Method label Classes.Check .Transfer := defMethod Check
-  (body := fun (self : Check) (args : Check.TransferArgs) =>
-    Program.return fun _ =>
-      {self with owner := args.newOwner : Check})
+  (body := fun (self : Check) (args : Check.TransferArgs) => ⟪
+    return
+      {self with owner := args.newOwner : Check}
+  ⟫)
   (invariant := fun (self : Check) (args : Check.TransferArgs) =>
     checkKey self.owner args.key)
 

--- a/Apps/OwnedCounter.lean
+++ b/Apps/OwnedCounter.lean
@@ -73,18 +73,17 @@ def incrementBy (step : Nat) (c : OwnedCounter) : OwnedCounter :=
   {c with count := c.count + step}
 
 def counterConstructor : @Class.Constructor label Classes.OwnedCounter Constructors.Zero := defConstructor
-  (body := fun (_noArgs : Unit) => Program.return fun _ => newCounter default)
+  (body := fun (_noArgs : Unit) => ⟪return newCounter default⟫)
 
 def counterIncr : @Class.Method label Classes.OwnedCounter Methods.Incr := defMethod OwnedCounter
-  (body := fun (self : OwnedCounter) (step : Nat) => Program.return fun _ => self.incrementBy step)
+  (body := fun (self : OwnedCounter) (step : Nat) => ⟪return self.incrementBy step⟫)
 
 def counterTransfer : @Class.Method label Classes.OwnedCounter Methods.Transfer := defMethod OwnedCounter
   (body := fun (self : OwnedCounter) (newOwner : PublicKey) =>
-    Program.return fun _ => {self with owner := newOwner : OwnedCounter})
+    ⟪return {self with owner := newOwner : OwnedCounter}⟫)
 
 /-- We only allow the counter to be destroyed if its count is at least 10 -/
 def counterDestroy : @Class.Destructor label Classes.OwnedCounter Destructors.Ten := defDestructor
-  (body := fun (_ : OwnedCounter) () => Program.return fun _ => ())
   (invariant := fun (self : OwnedCounter) () => self.count >= 10)
 
 def counterClass : @Class label Classes.OwnedCounter where

--- a/Apps/OwnedCounter.lean
+++ b/Apps/OwnedCounter.lean
@@ -84,8 +84,8 @@ def counterTransfer : @Class.Method label Classes.OwnedCounter Methods.Transfer 
 
 /-- We only allow the counter to be destroyed if its count is at least 10 -/
 def counterDestroy : @Class.Destructor label Classes.OwnedCounter Destructors.Ten := defDestructor
-  (body := fun (_ : OwnedCounter) (_ : PUnit) => Program.return fun _ => ())
-  (invariant := fun (self : OwnedCounter) (_ : PUnit) => self.count >= 10)
+  (body := fun (_ : OwnedCounter) () => Program.return fun _ => ())
+  (invariant := fun (self : OwnedCounter) () => self.count >= 10)
 
 def counterClass : @Class label Classes.OwnedCounter where
   constructors := fun

--- a/Apps/TwoCounter.lean
+++ b/Apps/TwoCounter.lean
@@ -148,10 +148,10 @@ def incrementBoth : @Class.Method Eco.lab Eco.Classes.TwoCounter Methods.Increme
   (body := fun (self : TwoCounter) (n : Nat) =>
     Program.fetch (fun _ => self.c1) <|
     Program.fetch (fun _ => self.c2) <|
-    Program.call Counter Counter.Methods.Incr (fun _ => self.c1)
+    Program.call (fun _ => self.c1) Counter.Methods.Incr
       (fun ⟨c1, ⟨c2, ()⟩⟩ =>
         c2.count * n + c1.count) <|
-    Program.call Counter Counter.Methods.Incr (fun _ => self.c2)
+    Program.call (fun _ => self.c2) Counter.Methods.Incr
       (fun ⟨c1, ⟨c2, ()⟩⟩ =>
         c1.count * n + c2.count) <|
     Program.return fun _ => self)

--- a/Apps/TwoCounter.lean
+++ b/Apps/TwoCounter.lean
@@ -121,11 +121,11 @@ instance instIsObject : IsObject Counter where
   fromObject := Counter.fromObject
 
 def constructor : @Class.Constructor Eco.lab Eco.Classes.Counter Constructors.Zero := defConstructor
-  (body := fun (_noArgs : Unit) => Program.return fun _ => Counter.new)
+  (body := fun (_noArgs : Unit) => ⟪return Counter.new⟫)
 
 def incr : @Class.Method Eco.lab Eco.Classes.Counter Methods.Incr := defMethod
   (body := fun (self : Counter) (step : Nat) =>
-    Program.return fun _ => self.incrementBy step)
+    ⟪return self.incrementBy step⟫)
 
 end Counter
 
@@ -138,23 +138,21 @@ instance instIsObject : IsObject TwoCounter where
   fromObject
 
 def constructor : @Class.Constructor Eco.lab Eco.Classes.TwoCounter Constructors.Zero := defConstructor
-  (body := fun (args : Reference Counter × Reference Counter) =>
-    Program.return fun _ =>
+  (body := fun (args : Reference Counter × Reference Counter) => ⟪
+    return
       { c1 := args.1
         c2 := args.2
-        : TwoCounter })
+        : TwoCounter }
+  ⟫)
 
 def incrementBoth : @Class.Method Eco.lab Eco.Classes.TwoCounter Methods.IncrementBoth := defMethod
-  (body := fun (self : TwoCounter) (n : Nat) =>
-    Program.fetch (fun _ => self.c1) <|
-    Program.fetch (fun _ => self.c2) <|
-    Program.call Counter Counter.Methods.Incr (fun _ => self.c1)
-      (fun ⟨c1, ⟨c2, ()⟩⟩ =>
-        c2.count * n + c1.count) <|
-    Program.call Counter Counter.Methods.Incr (fun _ => self.c2)
-      (fun ⟨c1, ⟨c2, ()⟩⟩ =>
-        c1.count * n + c2.count) <|
-    Program.return fun _ => self)
+  (body := fun (self : TwoCounter) (n : Nat) => ⟪
+    c1 := fetch self.c1
+    c2 := fetch self.c2
+    call Counter Counter.Methods.Incr self.c1 (c2.count * n + c1.count)
+    call Counter Counter.Methods.Incr self.c2 (c1.count * n + c2.count)
+    return self
+  ⟫)
 
 end TwoCounter
 

--- a/Apps/TwoCounter.lean
+++ b/Apps/TwoCounter.lean
@@ -148,10 +148,10 @@ def incrementBoth : @Class.Method Eco.lab Eco.Classes.TwoCounter Methods.Increme
   (body := fun (self : TwoCounter) (n : Nat) =>
     Program.fetch (fun _ => self.c1) <|
     Program.fetch (fun _ => self.c2) <|
-    Program.call (fun _ => self.c1) Counter.Methods.Incr
+    Program.call Counter Counter.Methods.Incr (fun _ => self.c1)
       (fun ⟨c1, ⟨c2, ()⟩⟩ =>
         c2.count * n + c1.count) <|
-    Program.call (fun _ => self.c2) Counter.Methods.Incr
+    Program.call Counter Counter.Methods.Incr (fun _ => self.c2)
       (fun ⟨c1, ⟨c2, ()⟩⟩ =>
         c1.count * n + c2.count) <|
     Program.return fun _ => self)

--- a/Apps/UniversalCounter.lean
+++ b/Apps/UniversalCounter.lean
@@ -63,10 +63,10 @@ def incrementBy (step : Nat) (c : Counter) : Counter :=
   {c with count := c.count + step}
 
 def counterConstructor : @Class.Constructor label Classes.Counter Constructors.Zero := defConstructor
-  (body := fun (_noArgs : Unit) => Program.return fun _ => newCounter)
+  (body := fun (_noArgs : Unit) => ⟪return newCounter⟫)
 
 def counterIncr : @Class.Method label Classes.Counter Methods.Incr := defMethod
-  (body := fun (self : Counter) (step : Nat) => Program.return fun _ => self.incrementBy step)
+  (body := fun (self : Counter) (step : Nat) => ⟪return self.incrementBy step⟫)
 
 def counterClass : @Class label Classes.Counter where
   constructors := fun

--- a/Prelude/LetBang.lean
+++ b/Prelude/LetBang.lean
@@ -2,9 +2,9 @@ syntax withPosition("let!" term (":" term)? ":=" term) optSemicolon(term) : term
 syntax withPosition("let!" term ":=" term) optSemicolon(doSeq) : doElem
 syntax withPosition("let!" term ":" term ":=" term) optSemicolon(doSeq) : doElem
 syntax withPosition("let!" term (":" term)? "←" term)  optSemicolon(doSeq) : doElem
-syntax withPosition("let!" term (":" term)? ":=" term) "failwith" term optSemicolon(term) : term
-syntax withPosition("let!" term (":" term)? ":=" term) "failwith" doSeq optSemicolon(doSeq) : doElem
-syntax withPosition("let!" term (":" term)? "←" term) "failwith" doSeq optSemicolon(doSeq) : doElem
+syntax withPosition("let!" term (":" term)? ":=" term) withPosition("failwith" term) optSemicolon(term) : term
+syntax withPosition("let!" term (":" term)? ":=" term) withPosition("failwith" doSeq) optSemicolon(doSeq) : doElem
+syntax withPosition("let!" term (":" term)? "←" term) withPosition("failwith" doSeq) optSemicolon(doSeq) : doElem
 
 /-- The `let! pat := v; b` syntax desugars to `match v with | pat => b | _ => default`.
   The value returned on failure (instead of `default`, when `v` does not match `pat`)

--- a/Prelude/LetTry.lean
+++ b/Prelude/LetTry.lean
@@ -1,9 +1,9 @@
 syntax withPosition("let" "try" term (":" term)? ":=" term) optSemicolon(term) : term
 syntax withPosition("let" "try" term (":" term)? ":=" term) optSemicolon(doSeq) : doElem
 syntax withPosition("let" "try" term (":" term)? "←" term)  optSemicolon(doSeq) : doElem
-syntax withPosition("let" "try" term (":" term)? ":=" term) "failwith" term optSemicolon(term) : term
-syntax withPosition("let" "try" term (":" term)? ":=" term) "failwith" doSeq optSemicolon(doSeq) : doElem
-syntax withPosition("let" "try" term (":" term)? "←" term) "failwith" doSeq optSemicolon(doSeq) : doElem
+syntax withPosition("let" "try" term (":" term)? ":=" term) withPosition("failwith" term) optSemicolon(term) : term
+syntax withPosition("let" "try" term (":" term)? ":=" term) withPosition("failwith" doSeq) optSemicolon(doSeq) : doElem
+syntax withPosition("let" "try" term (":" term)? "←" term) withPosition("failwith" doSeq) optSemicolon(doSeq) : doElem
 
 /-- The `let try x := ov; b` macro unwraps an `Option`, for `ov = some v` binds
   the value `v` to `x` in `b`, for `ov = none` returns `default`. The value

--- a/Tests.lean
+++ b/Tests.lean
@@ -1,0 +1,1 @@
+import Tests.Applib.Surface.Program.Syntax

--- a/Tests/Applib/Surface/Program/Syntax.lean
+++ b/Tests/Applib/Surface/Program/Syntax.lean
@@ -6,7 +6,7 @@ namespace TwoCounterApp
 
 open Applib
 
-def prog1 (rx ry : Reference Counter) : Program Eco.lab Counter := ⟪
+def example_1 (rx ry : Reference Counter) : Program Eco.lab Counter := ⟪
   x := fetch rx
   y := fetch ry
   call Counter Counter.Methods.Incr rx (x.count * 2 + y.count)
@@ -14,7 +14,7 @@ def prog1 (rx ry : Reference Counter) : Program Eco.lab Counter := ⟪
   return {x with count := x.count + y.count}
 ⟫
 
-def prog2 (rx ry : Reference Counter) : Program Eco.lab Unit := ⟪
+def example_2 (rx ry : Reference Counter) : Program Eco.lab Unit := ⟪
   x := fetch rx
   y := fetch ry
   call Counter Counter.Methods.Incr rx (x.count * 2 + y.count)
@@ -22,7 +22,7 @@ def prog2 (rx ry : Reference Counter) : Program Eco.lab Unit := ⟪
   return ()
 ⟫
 
-def prog3 : Program Eco.lab (Reference TwoCounter) := ⟪
+def example_3 : Program Eco.lab (Reference TwoCounter) := ⟪
   rx := create Counter Counter.Constructors.Zero ()
   ry := create Counter Counter.Constructors.Zero ()
   call Counter Counter.Methods.Incr rx (2 : Nat)
@@ -31,7 +31,7 @@ def prog3 : Program Eco.lab (Reference TwoCounter) := ⟪
   return tc
 ⟫
 
-def prog4 (self : TwoCounter) (n : Nat) : Program Eco.lab TwoCounter := ⟪
+def example_4 (self : TwoCounter) (n : Nat) : Program Eco.lab TwoCounter := ⟪
   c1 := fetch self.c1
   c2 := fetch self.c2
   call Counter Counter.Methods.Incr self.c1 (c2.count * n + c1.count)
@@ -45,7 +45,7 @@ namespace OwnedCounter
 
 open Applib
 
-def prog1 (r : Reference OwnedCounter) (newOwner : PublicKey) : Program label (Reference OwnedCounter) := ⟪
+def example_1 (r : Reference OwnedCounter) (newOwner : PublicKey) : Program label (Reference OwnedCounter) := ⟪
   c := fetch r
   call OwnedCounter OwnedCounter.Methods.Transfer r newOwner
   r' := create OwnedCounter OwnedCounter.Constructors.Zero ()
@@ -54,7 +54,7 @@ def prog1 (r : Reference OwnedCounter) (newOwner : PublicKey) : Program label (R
   return r'
 ⟫
 
-def prog2 (n : Nat) : Program label (Reference OwnedCounter) := ⟪
+def example_2 (n : Nat) : Program label (Reference OwnedCounter) := ⟪
   r := create OwnedCounter OwnedCounter.Constructors.Zero ()
   call OwnedCounter OwnedCounter.Methods.Incr r n
   create OwnedCounter OwnedCounter.Constructors.Zero ()

--- a/Tests/Applib/Surface/Program/Syntax.lean
+++ b/Tests/Applib/Surface/Program/Syntax.lean
@@ -6,7 +6,7 @@ namespace TwoCounterApp
 
 open Applib
 
-def example_1 (rx ry : Reference Counter) : Program Eco.lab Counter := ⟪
+example (rx ry : Reference Counter) : Program Eco.lab Counter := ⟪
   x := fetch rx
   y := fetch ry
   call Counter Counter.Methods.Incr rx (x.count * 2 + y.count)
@@ -14,7 +14,7 @@ def example_1 (rx ry : Reference Counter) : Program Eco.lab Counter := ⟪
   return {x with count := x.count + y.count}
 ⟫
 
-def example_2 (rx ry : Reference Counter) : Program Eco.lab Unit := ⟪
+example (rx ry : Reference Counter) : Program Eco.lab Unit := ⟪
   x := fetch rx
   y := fetch ry
   call Counter Counter.Methods.Incr rx (x.count * 2 + y.count)
@@ -22,7 +22,7 @@ def example_2 (rx ry : Reference Counter) : Program Eco.lab Unit := ⟪
   return ()
 ⟫
 
-def example_3 : Program Eco.lab (Reference TwoCounter) := ⟪
+example : Program Eco.lab (Reference TwoCounter) := ⟪
   rx := create Counter Counter.Constructors.Zero ()
   ry := create Counter Counter.Constructors.Zero ()
   call Counter Counter.Methods.Incr rx (2 : Nat)
@@ -31,7 +31,7 @@ def example_3 : Program Eco.lab (Reference TwoCounter) := ⟪
   return tc
 ⟫
 
-def example_4 (self : TwoCounter) (n : Nat) : Program Eco.lab TwoCounter := ⟪
+example (self : TwoCounter) (n : Nat) : Program Eco.lab TwoCounter := ⟪
   c1 := fetch self.c1
   c2 := fetch self.c2
   call Counter Counter.Methods.Incr self.c1 (c2.count * n + c1.count)
@@ -45,7 +45,7 @@ namespace OwnedCounter
 
 open Applib
 
-def example_1 (r : Reference OwnedCounter) (newOwner : PublicKey) : Program label (Reference OwnedCounter) := ⟪
+example (r : Reference OwnedCounter) (newOwner : PublicKey) : Program label (Reference OwnedCounter) := ⟪
   c := fetch r
   call OwnedCounter OwnedCounter.Methods.Transfer r newOwner
   r' := create OwnedCounter OwnedCounter.Constructors.Zero ()
@@ -54,7 +54,7 @@ def example_1 (r : Reference OwnedCounter) (newOwner : PublicKey) : Program labe
   return r'
 ⟫
 
-def example_2 (n : Nat) : Program label (Reference OwnedCounter) := ⟪
+example (n : Nat) : Program label (Reference OwnedCounter) := ⟪
   r := create OwnedCounter OwnedCounter.Constructors.Zero ()
   call OwnedCounter OwnedCounter.Methods.Incr r n
   create OwnedCounter OwnedCounter.Constructors.Zero ()

--- a/Tests/Applib/Surface/Program/Syntax.lean
+++ b/Tests/Applib/Surface/Program/Syntax.lean
@@ -1,24 +1,12 @@
 import Applib.Surface.Program.Syntax
 import Apps.TwoCounter
+import Apps.OwnedCounter
+
+namespace TwoCounterApp
 
 open Applib
-open TwoCounterApp
 
--- set_option trace.Elab.step true
-
-/-
-def Counter.prog0 : Program Eco.lab Counter :=
-Program.fetch  (  fun  _  => counterRef
-   )  <|
- Program.fetch  (  fun  ⟨ x  ,  _  ⟩  => counterRef
-   )  <|
- Program.call Counter Counter.Methods.Incr  (  fun  ⟨ x  ,  ⟨ y  ,  _  ⟩  ⟩  => counterRef  ) (  fun  ⟨ x  ,  ⟨ y  ,  _  ⟩  ⟩  => (x.count + y.count))
-   <|
- Program.return  (  fun  ⟨ x  ,  ⟨ y  ,  _  ⟩  ⟩  => {x with count := x.count + y.count}
- )
--/
-
-def Counter.prog1 (rx ry : Reference Counter) : Program Eco.lab Counter := ⟪
+def prog1 (rx ry : Reference Counter) : Program Eco.lab Counter := ⟪
   x := fetch rx
   y := fetch ry
   call Counter Counter.Methods.Incr rx (x.count * 2 + y.count)
@@ -26,10 +14,44 @@ def Counter.prog1 (rx ry : Reference Counter) : Program Eco.lab Counter := ⟪
   return {x with count := x.count + y.count}
 ⟫
 
-def Counter.prog2 (rx ry : Reference Counter) : Program Eco.lab Unit := ⟪
+def prog2 (rx ry : Reference Counter) : Program Eco.lab Unit := ⟪
   x := fetch rx
   y := fetch ry
   call Counter Counter.Methods.Incr rx (x.count * 2 + y.count)
   call Counter Counter.Methods.Incr ry (y.count * 2 + x.count)
   return ()
 ⟫
+
+def prog3 : Program Eco.lab (Reference TwoCounter) := ⟪
+  rx := create Counter Counter.Constructors.Zero ()
+  ry := create Counter Counter.Constructors.Zero ()
+  call Counter Counter.Methods.Incr rx (2 : Nat)
+  call Counter Counter.Methods.Incr ry (7 : Nat)
+  tc := create TwoCounter TwoCounter.Constructors.Zero (rx, ry)
+  return tc
+⟫
+
+def prog4 (self : TwoCounter) (n : Nat) : Program Eco.lab TwoCounter := ⟪
+  c1 := fetch self.c1
+  c2 := fetch self.c2
+  call Counter Counter.Methods.Incr self.c1 (c2.count * n + c1.count)
+  call Counter Counter.Methods.Incr self.c2 (c1.count * n + c2.count)
+  return self
+⟫
+
+end TwoCounterApp
+
+namespace OwnedCounter
+
+open Applib
+
+def prog1 (r : Reference OwnedCounter) (newOwner : PublicKey) : Program label (Reference OwnedCounter) := ⟪
+  c := fetch r
+  call OwnedCounter OwnedCounter.Methods.Transfer r newOwner
+  r' := create OwnedCounter OwnedCounter.Constructors.Zero ()
+  call OwnedCounter OwnedCounter.Methods.Incr r' (c.count + 1)
+  destroy OwnedCounter OwnedCounter.Destructors.Ten r ()
+  return r'
+⟫
+
+end OwnedCounter

--- a/Tests/Applib/Surface/Program/Syntax.lean
+++ b/Tests/Applib/Surface/Program/Syntax.lean
@@ -54,4 +54,12 @@ def prog1 (r : Reference OwnedCounter) (newOwner : PublicKey) : Program label (R
   return r'
 ⟫
 
+def prog2 (n : Nat) : Program label (Reference OwnedCounter) := ⟪
+  r := create OwnedCounter OwnedCounter.Constructors.Zero ()
+  call OwnedCounter OwnedCounter.Methods.Incr r n
+  create OwnedCounter OwnedCounter.Constructors.Zero ()
+  create OwnedCounter OwnedCounter.Constructors.Zero ()
+  return r
+⟫
+
 end OwnedCounter

--- a/Tests/Applib/Surface/Program/Syntax.lean
+++ b/Tests/Applib/Surface/Program/Syntax.lean
@@ -1,0 +1,35 @@
+import Applib.Surface.Program.Syntax
+import Apps.TwoCounter
+
+open Applib
+open TwoCounterApp
+
+-- set_option trace.Elab.step true
+
+/-
+def Counter.prog0 : Program Eco.lab Counter :=
+Program.fetch  (  fun  _  => counterRef
+   )  <|
+ Program.fetch  (  fun  ⟨ x  ,  _  ⟩  => counterRef
+   )  <|
+ Program.call Counter Counter.Methods.Incr  (  fun  ⟨ x  ,  ⟨ y  ,  _  ⟩  ⟩  => counterRef  ) (  fun  ⟨ x  ,  ⟨ y  ,  _  ⟩  ⟩  => (x.count + y.count))
+   <|
+ Program.return  (  fun  ⟨ x  ,  ⟨ y  ,  _  ⟩  ⟩  => {x with count := x.count + y.count}
+ )
+-/
+
+def Counter.prog1 (rx ry : Reference Counter) : Program Eco.lab Counter := ⟪
+  x := fetch rx
+  y := fetch ry
+  call Counter Counter.Methods.Incr rx (x.count * 2 + y.count)
+  call Counter Counter.Methods.Incr ry (y.count * 2 + x.count)
+  return {x with count := x.count + y.count}
+⟫
+
+def Counter.prog2 (rx ry : Reference Counter) : Program Eco.lab Unit := ⟪
+  x := fetch rx
+  y := fetch ry
+  call Counter Counter.Methods.Incr rx (x.count * 2 + y.count)
+  call Counter Counter.Methods.Incr ry (y.count * 2 + x.count)
+  return ()
+⟫

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,6 +1,6 @@
 name = "goose"
 version = "0.1.0"
-defaultTargets = ["Prelude", "Anoma", "AVM", "Applib", "Apps"]
+defaultTargets = ["Prelude", "Anoma", "AVM", "Applib", "Apps", "Tests"]
 
 [[require]]
 name = "mathlib"
@@ -24,3 +24,6 @@ name = "Applib"
 
 [[lean_lib]]
 name = "Apps"
+
+[[lean_lib]]
+name = "Tests"


### PR DESCRIPTION
Introduces macros which allow to write Applib Programs in a convenient syntax with binders, e.g.,
```
⟪
  c1 := fetch self.c1
  c2 := fetch self.c2
  call Counter Counter.Methods.Incr self.c1 (c2.count * n + c1.count)
  call Counter Counter.Methods.Incr self.c2 (c1.count * n + c2.count)
  return self
⟫
```
