### PR TITLE
Update README for clarity on GOOSE structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 This repository contains GOOSE specification in Lean 4. GOOSE provides an object-oriented abstraction on top of the Anoma Resource Machine.
 
 GOOSE consists of three layers:
-1. Surface syntax for defining classes, methods, and other object-oriented constructs. The syntax is implemented using Lean 4's macro system and it desugars to the Anoma Virtual Machine (AVM) object structures.
+1. Surface syntax for defining classes, methods, and other object-oriented constructs (`Applib` directory). The syntax is implemented using Lean 4's macro system and it desugars to the Anoma Virtual Machine (AVM) object structures.
 2. Anoma Virtual Machine object structures (`AVM` directory) provide representations of objects, methods, classes, etc. These constitute the AVM object model and are translated to the Anoma Resource Machine structures.
 3. Anoma Resource Machine structures (`Anoma` directory).
+
+Example Anoma applications implemented with the GOOSE framework are available in the `Apps` directory.
 
 ## Building documentation
 


### PR DESCRIPTION
Clarified README by specifying the 'Applib' directory for surface syntax and added mention of example applications in the 'Apps' directory.