### PR TITLE
Simplify AVM.Program implementation

### DIFF
--- a/Applib/Surface/Program.lean
+++ b/Applib/Surface/Program.lean
@@ -89,7 +89,15 @@ def Program.create'
   : Program i.label ReturnType :=
   Program.create C i.classId constrId args (fun objId => next ⟨objId⟩)
 
-def Program.destroy' {ReturnType} {C : Type} (r : Reference C) [i : IsObject C] (destrId : i.classId.label.DestructorId) (args : destrId.Args.type) (next : Program i.label ReturnType) : Program i.label ReturnType :=
+def Program.destroy'
+  {ReturnType}
+  {C : Type}
+  (r : Reference C)
+  [i : IsObject C]
+  (destrId : i.classId.label.DestructorId)
+  (args : destrId.Args.type)
+  (next : Program i.label ReturnType)
+  : Program i.label ReturnType :=
   Program.destroy i.classId destrId r.objId args next
 
 def Program.call' {ReturnType} {C : Type} (r : Reference C) [i : IsObject C] (methodId : i.classId.label.MethodId) (args : methodId.Args.type) (next : Program i.label ReturnType) : Program i.label ReturnType :=

--- a/Applib/Surface/Program.lean
+++ b/Applib/Surface/Program.lean
@@ -100,7 +100,15 @@ def Program.destroy'
   : Program i.label ReturnType :=
   Program.destroy i.classId destrId r.objId args next
 
-def Program.call' {ReturnType} {C : Type} (r : Reference C) [i : IsObject C] (methodId : i.classId.label.MethodId) (args : methodId.Args.type) (next : Program i.label ReturnType) : Program i.label ReturnType :=
+def Program.call'
+  {ReturnType}
+  {C : Type}
+  (r : Reference C)
+  [i : IsObject C]
+  (methodId : i.classId.label.MethodId)
+  (args : methodId.Args.type)
+  (next : Program i.label ReturnType)
+  : Program i.label ReturnType :=
   Program.call i.classId methodId r.objId args next
 
 def Program.fetch' {ReturnType} {lab : Ecosystem.Label} {C : Type} (r : Reference C) [i : IsObject C] (next : C → Program lab ReturnType) : Program lab ReturnType :=

--- a/Applib/Surface/Program.lean
+++ b/Applib/Surface/Program.lean
@@ -79,7 +79,14 @@ def Program.map {lab : Ecosystem.Label} {A B : Type} (f : A → B) (prog : Progr
   | .return val =>
     .return (f val)
 
-def Program.create' {ReturnType} (C : Type) [i : IsObject C] (constrId : i.classId.label.ConstructorId) (args : constrId.Args.type) (next : Reference C → Program i.label ReturnType) : Program i.label ReturnType :=
+def Program.create'
+  {ReturnType}
+  (C : Type)
+  [i : IsObject C]
+  (constrId : i.classId.label.ConstructorId)
+  (args : constrId.Args.type)
+  (next : Reference C → Program i.label ReturnType)
+  : Program i.label ReturnType :=
   Program.create C i.classId constrId args (fun objId => next ⟨objId⟩)
 
 def Program.destroy' {ReturnType} {C : Type} (r : Reference C) [i : IsObject C] (destrId : i.classId.label.DestructorId) (args : destrId.Args.type) (next : Program i.label ReturnType) : Program i.label ReturnType :=

--- a/Applib/Surface/Program.lean
+++ b/Applib/Surface/Program.lean
@@ -6,58 +6,50 @@ namespace Applib
 
 open AVM
 
-inductive Program.Sized (lab : Ecosystem.Label) : (ReturnType : Type) → Nat → Type 2 where
+inductive Program (lab : Ecosystem.Label) : (ReturnType : Type) → Type 2 where
   | create
     {ReturnType : Type}
-    {n : Nat}
     (C : Type)
     (cid : lab.ClassId)
     (constrId : cid.label.ConstructorId)
     (args : constrId.Args.type)
-    (next : ObjectId → Program.Sized lab ReturnType n)
-    : Program.Sized lab ReturnType (n + 1)
+    (next : ObjectId → Program lab ReturnType)
+    : Program lab ReturnType
   | destroy
     {ReturnType : Type}
-    {n : Nat}
     (cid : lab.ClassId)
     (destrId : cid.label.DestructorId)
     (selfId : ObjectId)
     (args : destrId.Args.type)
-    (next : Program.Sized lab ReturnType n)
-    : Program.Sized lab ReturnType (n + 1)
+    (next : Program lab ReturnType)
+    : Program lab ReturnType
   | call
     {ReturnType : Type}
-    {n : Nat}
     (cid : lab.ClassId)
     (methodId : cid.label.MethodId)
     (selfId : ObjectId)
     (args : methodId.Args.type)
-    (next : Program.Sized lab ReturnType n)
-    : Program.Sized lab ReturnType (n + 1)
+    (next : Program lab ReturnType)
+    : Program lab ReturnType
   | fetch
     {ReturnType : Type}
-    {n : Nat}
     (C : Type)
     [i : IsObject C]
     (objId : ObjectId)
-    (next : C → Program.Sized lab ReturnType n)
-    : Program.Sized lab ReturnType (n + 1)
+    (next : C → Program lab ReturnType)
+    : Program lab ReturnType
   | invoke
     {ReturnType : Type}
-    {n : Nat}
     {α : Type}
-    (prog : Program.Sized lab α n)
-    (next : α → Program.Sized lab ReturnType n)
-    : Program.Sized lab ReturnType (n + 1)
+    (prog : Program lab α)
+    (next : α → Program lab ReturnType)
+    : Program lab ReturnType
   | return
     {ReturnType : Type}
-    {n : Nat}
     (val : ReturnType)
-    : Program.Sized lab ReturnType n
+    : Program lab ReturnType
 
-def Program lab ReturnType := Σ n, Program.Sized lab ReturnType n
-
-def Program.Sized.toAVM {n : Nat} {lab ReturnType} (prog : Program.Sized lab ReturnType n) : AVM.Program.Sized lab ReturnType n :=
+def Program.toAVM {lab ReturnType} (prog : Program lab ReturnType) : AVM.Program lab ReturnType :=
   match prog with
   | .create _ cid constrId args next =>
     .constructor cid constrId args (fun objId => toAVM (next objId))
@@ -65,14 +57,14 @@ def Program.Sized.toAVM {n : Nat} {lab ReturnType} (prog : Program.Sized lab Ret
     .destructor cid destrId selfId args (toAVM next)
   | .call cid methodId selfId args next =>
     .method cid methodId selfId args (toAVM next)
-  | @fetch _ _ _ _ i objId next =>
+  | @fetch _ _ _ i objId next =>
     .fetch ⟨i.classId.label, objId⟩ (fun obj => toAVM (next (i.fromObject obj.data)))
   | .invoke p next =>
     .invoke (toAVM p) (fun x => toAVM (next x))
   | .return val =>
     .return val
 
-def Program.Sized.map {n : Nat} {lab : Ecosystem.Label} {A B : Type} (f : A → B) (prog : Program.Sized lab A n) : Program.Sized lab B n :=
+def Program.map {lab : Ecosystem.Label} {A B : Type} (f : A → B) (prog : Program lab A) : Program lab B :=
   match prog with
   | .create C cid constrId args next =>
     .create C cid constrId args (fun x => map f (next x))
@@ -80,57 +72,21 @@ def Program.Sized.map {n : Nat} {lab : Ecosystem.Label} {A B : Type} (f : A → 
     .destroy cid destrId selfId args (map f next)
   | .call cid methodId selfId args next =>
     .call cid methodId selfId args (map f next)
-  | @fetch _ _ _ C _ objId next =>
+  | @fetch _ _ C _ objId next =>
     .fetch C objId (fun x => map f (next x))
   | .invoke p next =>
     .invoke p (fun x => map f (next x))
   | .return val =>
     .return (f val)
 
-def Program.Sized.lift {n m : Nat} {lab : Ecosystem.Label} {ReturnType} (prog : Program.Sized lab ReturnType n) : Program.Sized lab ReturnType (m + n) :=
-  match prog with
-  | .create C cid constrId args next =>
-    .create C cid constrId args (fun x => lift (next x))
-  | .destroy cid destrId selfId args next =>
-    .destroy cid destrId selfId args (lift next)
-  | .call cid methodId selfId args next =>
-    .call cid methodId selfId args (lift next)
-  | @fetch _ _ _ C _ objId next =>
-    .fetch C objId (fun x => lift (next x))
-  | .invoke p next =>
-    .invoke (lift p) (fun x => lift (next x))
-  | .return val =>
-    .return val
+def Program.create' {ReturnType} (C : Type) [i : IsObject C] (constrId : i.classId.label.ConstructorId) (args : constrId.Args.type) (next : Reference C → Program i.label ReturnType) : Program i.label ReturnType :=
+  Program.create C i.classId constrId args (fun objId => next ⟨objId⟩)
 
-def Program.Sized.lift' {n m : Nat} {lab : Ecosystem.Label} {ReturnType} (prog : Program.Sized lab ReturnType n) : Program.Sized lab ReturnType (n + m) :=
-  cast (by rw [Nat.add_comm]) (Program.Sized.lift (m := m) prog)
+def Program.destroy' {ReturnType} {C : Type} (r : Reference C) [i : IsObject C] (destrId : i.classId.label.DestructorId) (args : destrId.Args.type) (next : Program i.label ReturnType) : Program i.label ReturnType :=
+  Program.destroy i.classId destrId r.objId args next
 
-def Program.Sized.create' {n : Nat} {ReturnType} (C : Type) [i : IsObject C] (constrId : i.classId.label.ConstructorId) (args : constrId.Args.type) (next : Reference C → Program.Sized i.label ReturnType n) : Program.Sized i.label ReturnType (n + 1) :=
-  Program.Sized.create C i.classId constrId args (fun objId => next ⟨objId⟩)
+def Program.call' {ReturnType} {C : Type} (r : Reference C) [i : IsObject C] (methodId : i.classId.label.MethodId) (args : methodId.Args.type) (next : Program i.label ReturnType) : Program i.label ReturnType :=
+  Program.call i.classId methodId r.objId args next
 
-def Program.Sized.destroy' {n : Nat} {ReturnType} {C : Type} (r : Reference C) [i : IsObject C] (destrId : i.classId.label.DestructorId) (args : destrId.Args.type) (next : Program.Sized i.label ReturnType n) : Program.Sized i.label ReturnType (n + 1) :=
-  Program.Sized.destroy i.classId destrId r.objId args next
-
-def Program.Sized.call' {n : Nat} {ReturnType} {C : Type} (r : Reference C) [i : IsObject C] (methodId : i.classId.label.MethodId) (args : methodId.Args.type) (next : Program.Sized i.label ReturnType n) : Program.Sized i.label ReturnType (n + 1) :=
-  Program.Sized.call i.classId methodId r.objId args next
-
-def Program.Sized.fetch' {n : Nat} {ReturnType} {lab : Ecosystem.Label} {C : Type} (r : Reference C) [i : IsObject C] (next : C → Program.Sized lab ReturnType n) : Program.Sized lab ReturnType (n + 1) :=
-  Program.Sized.fetch C r.objId next
-
-def Program.Sized.invoke' {n : Nat} {lab : Ecosystem.Label} {ReturnType α : Type} (prog : Program lab α) (next : α → Program.Sized lab ReturnType n) : Program.Sized lab ReturnType (prog.fst + n + 1) :=
-  Program.Sized.invoke prog.snd.lift' (fun x => next x |>.lift)
-
-def Program.Sized.return' {lab : Ecosystem.Label} {ReturnType} (val : ReturnType) : Program.Sized lab ReturnType 0 :=
-  Program.Sized.return val
-
-def Program.Sized.toProgram {n : Nat} {lab ReturnType} (prog : Program.Sized lab ReturnType n) : Program lab ReturnType :=
-  ⟨n, prog⟩
-
-def Program.map {lab : Ecosystem.Label} {A B : Type} (f : A → B) (prog : Program lab A) : Program lab B :=
-  ⟨prog.1, prog.2.map f⟩
-
-def Program.return {lab : Ecosystem.Label} {ReturnType} (val : ReturnType) : Program lab ReturnType :=
-  ⟨0, .return val⟩
-
-def Program.toAVM {lab : Ecosystem.Label} {ReturnType} (prog : Program lab ReturnType) : AVM.Program lab ReturnType :=
-  ⟨prog.1, prog.2.toAVM⟩
+def Program.fetch' {ReturnType} {lab : Ecosystem.Label} {C : Type} (r : Reference C) [i : IsObject C] (next : C → Program lab ReturnType) : Program lab ReturnType :=
+  Program.fetch C r.objId next

--- a/Applib/Surface/Program/Syntax.lean
+++ b/Applib/Surface/Program/Syntax.lean
@@ -14,25 +14,22 @@ syntax withPosition("invoke " term) optSemicolon(program) : program
 syntax withPosition(ident " := " " invoke " term) optSemicolon(program) : program
 syntax withPosition(ident " := " " fetch " term) optSemicolon(program) : program
 syntax "return " term : program
-syntax "Ξ " program : term
 syntax "⟪" program "⟫" : term
 
 macro_rules
-  | `(⟪$p:program⟫) => do
-    `(Program.Sized.toProgram (Ξ $p))
-  | `(Ξ create $c:ident $m:ident $e:term ; $p:program) => do
-    `(Program.Sized.create' $c $m $e (fun _ => Ξ $p))
-  | `(Ξ $x:ident := create $c:ident $m:ident $e:term ; $p:program) => do
-    `(Program.Sized.create' $c $m $e (fun $x => Ξ $p))
-  | `(Ξ destroy $m:ident $e:term $args:term ; $p:program) => do
-    `(Program.Sized.destroy' $e $m $args (Ξ $p))
-  | `(Ξ call $m:ident $e:term $args:term ; $p:program) => do
-    `(Program.Sized.call' $e $m $args (Ξ $p))
-  | `(Ξ invoke $e:term ; $p:program) => do
-    `(Program.Sized.invoke' $e (fun _ => Ξ $p))
-  | `(Ξ $x:ident := invoke $e:term ; $p:program) => do
-    `(Program.Sized.invoke' $e (fun $x => Ξ $p))
-  | `(Ξ $x:ident := fetch $e:term ; $p:program) => do
-    `(Program.Sized.fetch' $e (fun $x => Ξ $p))
-  | `(Ξ return $e:term) => do
-    `(Program.Sized.return' $e)
+  | `(⟪create $c:ident $m:ident $e:term ; $p:program⟫) => do
+    `(Program.create' $c $m $e (fun _ => ⟪$p⟫))
+  | `(⟪$x:ident := create $c:ident $m:ident $e:term ; $p:program⟫) => do
+    `(Program.create' $c $m $e (fun $x => ⟪$p⟫))
+  | `(⟪destroy $m:ident $e:term $args:term ; $p:program⟫) => do
+    `(Program.destroy' $e $m $args (⟪$p⟫))
+  | `(⟪call $m:ident $e:term $args:term ; $p:program⟫) => do
+    `(Program.call' $e $m $args (⟪$p⟫))
+  | `(⟪invoke $e:term ; $p:program⟫) => do
+    `(Program.invoke $e (fun _ => ⟪$p⟫))
+  | `(⟪$x:ident := invoke $e:term ; $p:program⟫) => do
+    `(Program.invoke $e (fun $x => ⟪$p⟫))
+  | `(⟪$x:ident := fetch $e:term ; $p:program⟫) => do
+    `(Program.fetch' $e (fun $x => ⟪$p⟫))
+  | `(⟪return $e:term⟫) => do
+    `(Program.return $e)


### PR DESCRIPTION
- Simplifies AVM.Program by removing the `invoke` constructor and implementing it as a function instead