### PR TITLE
Remove TypedObjectId and AnObject

### DIFF
--- a/AVM/Class/Translation/Tasks.lean
+++ b/AVM/Class/Translation/Tasks.lean
@@ -58,13 +58,13 @@ private partial def Body.tasks'
         |>.map (fun res => ⟨res.value, res.adjust, ⟨newId, res.bodyParameterValues⟩⟩)
   | .destructor classId destrId selfId args next =>
     let destr := eco.classes classId |>.destructors destrId
-    Tasks.fetch ⟨classId.label, selfId⟩ fun self => Tasks.rand fun r =>
+    Tasks.fetch selfId fun self => Tasks.rand fun r =>
       let task := destr.task' adjust eco r (adjust self) args
       Tasks.task task.task fun vals =>
         Body.tasks' (task.adjust vals) eco next
   | .method classId methodId selfId args next =>
     let method := eco.classes classId |>.methods methodId
-    Tasks.fetch ⟨classId.label, selfId⟩ fun self => Tasks.rand fun r =>
+    Tasks.fetch selfId fun self => Tasks.rand fun r =>
       let task := method.task' adjust eco r (adjust self) args
       Tasks.task task.task fun vals =>
         Body.tasks' (task.adjust vals) eco next

--- a/AVM/Object.lean
+++ b/AVM/Object.lean
@@ -3,10 +3,6 @@ import AVM.Class.Label
 
 namespace AVM
 
-structure TypedObjectId where
-  classLabel : Class.Label
-  uid : ObjectId
-
 structure ObjectData (lab : Class.Label) where
   /-- Object quantity, stored in the `quantity` field of the resource. -/
   quantity : Nat

--- a/AVM/Program.lean
+++ b/AVM/Program.lean
@@ -32,8 +32,9 @@ inductive Program.{u} (lab : Ecosystem.Label) (ReturnType : Type u) : Type (u + 
     : Program lab ReturnType
   | /-- Object fetch by object id. -/
     fetch
-    (objId : TypedObjectId)
-    (next : Object objId.classLabel → Program lab ReturnType)
+    {classLabel : Class.Label}
+    (objId : ObjectId)
+    (next : Object classLabel → Program lab ReturnType)
     : Program lab ReturnType
   | /-- Return value. -/
     return

--- a/AVM/Program/Parameters.lean
+++ b/AVM/Program/Parameters.lean
@@ -6,7 +6,7 @@ namespace AVM
   random values generated and the objects fetched inside the program. -/
 inductive Program.Parameters where
   | empty
-  | fetch (param : TypedObjectId) (rest : Object param.classLabel → Program.Parameters)
+  | fetch {classLabel : Class.Label} (objId : ObjectId) (rest : Object classLabel → Program.Parameters)
   | rand (rest : Nat → Program.Parameters)
 deriving Inhabited, Nonempty
 
@@ -31,8 +31,8 @@ def Program.Parameters.genId (rest : ObjectId → Program.Parameters) : Program.
 def Program.Parameters.Product (params : Program.Parameters) : Type u :=
   match params with
   | .empty => PUnit
-  | .fetch param rest =>
-    Σ (obj : Object param.classLabel), Program.Parameters.Product (rest obj)
+  | .fetch (classLabel := clab) _ rest =>
+    Σ (obj : Object clab), Program.Parameters.Product (rest obj)
   | .rand rest =>
     Σ (r : Nat), Program.Parameters.Product (rest r)
 

--- a/AVM/Task.lean
+++ b/AVM/Task.lean
@@ -41,7 +41,7 @@ def Task.absorbGenId (task : ObjectId → Task) : Task :=
     (Program.Parameters.genId (fun _ => .empty))
     (fun ⟨newId, ()⟩ => task newId)
 
-def Task.absorbFetch (param : TypedObjectId) (task : Object param.classLabel → Task) : Task :=
+def Task.absorbFetch {classLabel : Class.Label} (objId : ObjectId) (task : Object classLabel → Task) : Task :=
   Task.absorbParams
-    (Program.Parameters.fetch param (fun _ => .empty))
+    (Program.Parameters.fetch objId (fun _ => .empty))
     (fun ⟨obj, ()⟩ => task obj)

--- a/AVM/Task/Translation.lean
+++ b/AVM/Task/Translation.lean
@@ -24,10 +24,10 @@ def toTransaction (task : Task) (vals : task.params.Product) : Rand (Option Anom
 private def resolveParameters (params : Program.Parameters) (cont : params.Product → Anoma.Program) : Anoma.Program :=
   match params with
   | .empty => cont PUnit.unit
-  | .fetch p ps =>
-    Anoma.Program.queryResource (Anoma.Program.ResourceQuery.queryByObjectId p.uid) (fun res =>
-      let try obj : Object p.classLabel := Object.fromResource res
-          failwith Anoma.Program.raise <| Anoma.Program.Error.typeError ("expected object of class " ++ p.classLabel.name)
+  | .fetch (classLabel := clab) p ps =>
+    Anoma.Program.queryResource (Anoma.Program.ResourceQuery.queryByObjectId p) (fun res =>
+      let try obj : Object clab := Object.fromResource res
+          failwith Anoma.Program.raise <| Anoma.Program.Error.typeError ("expected object of class " ++ clab.name)
       resolveParameters (ps obj) (fun vals => cont ⟨obj, vals⟩))
   | .genId ps =>
     Anoma.Program.genObjectId (fun objId =>

--- a/AVM/Tasks.lean
+++ b/AVM/Tasks.lean
@@ -15,7 +15,7 @@ inductive Tasks (α : Type u) where
     unadjusted original object value and is supposed to adjust it by the
     modifications to that object that occurred from the start of the program up
     to the fetch. -/
-  | fetch (param : TypedObjectId) (rest : Object param.classLabel → Tasks α) : Tasks α
+  | fetch {classLabel : Class.Label} (objId : ObjectId) (rest : Object classLabel → Tasks α) : Tasks α
   | rand (rest : Nat → Tasks α) : Tasks α
   | result (value : α) : Tasks α
   deriving Inhabited

--- a/Applib/Surface/Object.lean
+++ b/Applib/Surface/Object.lean
@@ -16,21 +16,3 @@ lemma IsObject.left_inverse' {S : Type} [i : IsObject S] (s : S)
   rw [← Function.comp_apply (f := fromObject) (g := toObject)]
   rw [i.left_inverse]
   rfl
-
-structure AnObjectType : Type 1 where
-  ty : Type
-  [isObject : IsObject ty]
-
-structure AnObject : Type 1 where
-  {ty : Type}
-  [isObject : IsObject ty]
-  obj : ty
-
-def IsObject.toAnObject {cl : Type} [i : IsObject cl] (o : cl) : AnObject := ⟨o⟩
-
-def AnObject.toSomeObject (g : AnObject) : SomeObjectData :=
-  let i : IsObject g.ty := g.isObject
-  (i.toObject g.obj).toSomeObjectData
-
-instance {ty : Type} [IsObject ty] : CoeHead ty AnObject where
-  coe (obj : ty) := {obj}

--- a/Applib/Surface/Program.lean
+++ b/Applib/Surface/Program.lean
@@ -58,7 +58,7 @@ def Program.toAVM {lab ReturnType} (prog : Program lab ReturnType) : AVM.Program
   | .call cid methodId selfId args next =>
     .method cid methodId selfId args (toAVM next)
   | @fetch _ _ _ i objId next =>
-    .fetch ⟨i.classId.label, objId⟩ (fun obj => toAVM (next (i.fromObject obj.data)))
+    .fetch (classLabel := i.classId.label) objId (fun obj => toAVM (next (i.fromObject obj.data)))
   | .invoke p next =>
     .invoke (toAVM p) (fun x => toAVM (next x))
   | .return val =>


### PR DESCRIPTION
- Removes `TypedObjectId` in favour of having a separate field with the class label in the `fetch` constructors. This makes the handling of object ids more uniform.
- Removes the unused `AnObject` type from `Applib.Surface.Object`
