### PR TITLE
fix: include ephemeral object resources in recipients of multi-method messages

### DIFF
--- a/AVM/Class/Translation/Logics.lean
+++ b/AVM/Class/Translation/Logics.lean
@@ -102,12 +102,11 @@ private def logicFun
   | Consumed =>
     let consumedObjectResources : List Anoma.Resource := Logic.selectObjectResources args.consumed
     let! [consumedMessageResource] := Logic.selectMessageResources args.consumed
-    let try msg : Message lab := Message.fromResource consumedMessageResource
     -- Note: the success of the `try` below ensures that the message is "legal"
     -- for the consumed objects - it is from the same ecosystem
-    let recipients := msg.recipients.toList
-    self.uid ∈ recipients
-    && recipients.length == consumedObjectResources.length
+    let try msg : Message lab := Message.fromResource consumedMessageResource
+    self.uid ∈ msg.recipients
+    && msg.recipients.length == consumedObjectResources.length
     -- Note that the message logics already check if the consumed object
     -- resources have the right form, i.e., correspond to the self / selves. We
     -- only need to check that the number of recipients is equal to the number

--- a/AVM/Class/Translation/Messages.lean
+++ b/AVM/Class/Translation/Messages.lean
@@ -20,7 +20,7 @@ def Constructor.message
     logicRef := Constructor.Message.logic.{0, 0} constr |>.reference
     vals,
     args,
-    recipients := List.Vector.singleton newId }
+    recipients := [newId] }
 
 def Destructor.message
   {lab : Ecosystem.Label}
@@ -37,7 +37,7 @@ def Destructor.message
     logicRef := Destructor.Message.logic.{0, 0} destr |>.reference
     vals
     args
-    recipients := List.Vector.singleton selfId }
+    recipients := [selfId] }
 
 def Method.message
   {lab : Ecosystem.Label}
@@ -54,7 +54,7 @@ def Method.message
     logicRef := Method.Message.logic.{0, 0} method |>.reference
     vals
     args
-    recipients := List.Vector.singleton selfId }
+    recipients := [selfId] }
 
 def Upgrade.message
   {lab : Ecosystem.Label}
@@ -67,7 +67,7 @@ def Upgrade.message
     Vals := ⟨PUnit⟩
     vals := PUnit.unit
     args := .unit
-    recipients := List.Vector.singleton selfId }
+    recipients := [selfId] }
 
 end AVM.Class
 
@@ -79,15 +79,17 @@ def MultiMethod.message
   (method : MultiMethod multiId)
   (selves : multiId.Selves)
   (args : multiId.Args.type)
-  (body : Program lab (MultiMethodResult multiId))
-  (vals : body.params.Product)
+  (Vals : SomeType)
+  (vals : Vals.type)
+  (data : MultiMethodData)
+  (rands : MultiMethodRandoms data)
   : Message lab :=
-  let res : MultiMethodResult multiId := body.value vals
-  let data := res.data
   { id := .multiMethodId multiId
     logicRef := MultiMethod.Message.logic.{0, 0} method data |>.reference
     data
-    Vals := ⟨body.params.Product⟩
+    Vals
     vals
     args
-    recipients := Label.MultiMethodId.SelvesToVector selves (fun obj => obj.uid) }
+    recipients :=
+      (Label.MultiMethodId.SelvesToVector selves (fun obj => obj.uid) |>.toList)
+        ++ rands.constructedNonces.toList.map (·.value) }

--- a/AVM/Ecosystem/Label/Base.lean
+++ b/AVM/Ecosystem/Label/Base.lean
@@ -137,6 +137,7 @@ instance hasBEq {lab : Ecosystem.Label} : BEq (Ecosystem.Label.MemberId lab) whe
     | _, multiMethodId _ => false
     | classMember c1, classMember c2 => c1 === c2
 
+/-- The number of object arguments (selves) for this member ID. -/
 def numObjectArgs {lab : Ecosystem.Label} (memberId : MemberId lab) : Nat :=
   match memberId with
   | multiMethodId f => f.numObjectArgs

--- a/AVM/Message/Base.lean
+++ b/AVM/Message/Base.lean
@@ -20,7 +20,7 @@ structure Message (lab : Ecosystem.Label) : Type 1 where
   /-- Extra data. -/
   data : id.Data
   /-- The recipients of the message. -/
-  recipients : List.Vector ObjectId id.numObjectArgs
+  recipients : List ObjectId
 
 instance Message.hasTypeRep (lab : Ecosystem.Label) : TypeRep (Message lab) where
   rep := Rep.composite "AVM.Message" [Rep.atomic lab.name]
@@ -51,7 +51,7 @@ instance : Inhabited SomeMessage where
                   logicRef := default
                   id := .classMember (classId := .unit) (.constructorId PUnit.unit),
                   args := PUnit.unit
-                  recipients := List.Vector.singleton 0 }}
+                  recipients := [] }}
 
 def Message.toSomeMessage {lab : Ecosystem.Label} (msg : Message lab) : SomeMessage :=
   { label := lab, message := msg }


### PR DESCRIPTION
Not including them as recipients resulted in incorrect class logic - it checked if every consumed resource is a recipient. For the constructor message, the created object is the recipient, so it's consistent now.

