### PR TITLE
fix: Require authorization from the check owner

### DIFF
--- a/Apps/KudosBank.lean
+++ b/Apps/KudosBank.lean
@@ -547,7 +547,7 @@ def issueCheck : @Ecosystem.MultiMethod label .IssueCheck :=
     ⟫)
   (invariant := fun selves args signatures =>
     let bank := selves .bank
-    checkSignature (signatures .owner) bank.owner
+    checkSignature (signatures .owner) args.owner
     && 0 < args.quantity
     && args.quantity <= bank.getBalance args.owner args.denomination)
 


### PR DESCRIPTION
When issuing a check, the signature should be from the owner of the check, not the bank