### PR TITLE
feat: Add runnable resource machine model

### DIFF
--- a/AVM/Action.lean
+++ b/AVM/Action.lean
@@ -17,7 +17,7 @@ def CreatedObject.toObject (c : CreatedObject) : Object c.classId :=
   let nonce := res.nullifyUniversal.nullifier.toNonce
   {uid := c.uid, nonce, data := c.data}
 
-def CreatedObject.toResource (c : CreatedObject) : Anoma.Resource :=
+def CreatedObject.toResource (c : CreatedObject) : Anoma.Resource.{1, 1} :=
   c.toObject.toResource (ephemeral := c.ephemeral)
 
 def Action.create'
@@ -27,15 +27,15 @@ def Action.create'
   (ensureUnique : List Anoma.Nonce)
   (consumedMessages : List SomeMessage)
   (createdMessages : List SomeMessage)
-  : Anoma.Action × Anoma.DeltaWitness × StdGen :=
-  let (createdWitnesses, g') : List Anoma.ComplianceWitness × StdGen :=
+  : Anoma.Action.{1, 1} × Anoma.DeltaWitness × StdGen :=
+  let (createdWitnesses, g') : List Anoma.ComplianceWitness.{1, 1} × StdGen :=
     ([], g) |>
     createdObjects.foldr mkCreatedComplianceWitness |>
     ensureUnique.foldr mkDummyComplianceWitness |>
     createdMessages.foldr mkCreatedMessageComplianceWitness
   let createdUnits : List Anoma.ComplianceUnit :=
     createdWitnesses.map Anoma.ComplianceUnit.create
-  let (consumedWitnesses, g'') : List Anoma.ComplianceWitness × StdGen :=
+  let ((consumedWitnesses : List Anoma.ComplianceWitness.{1, 1}), g'') : List Anoma.ComplianceWitness × StdGen :=
     ([], g') |>
     consumedObjects.foldr mkConsumedComplianceWitness |>
     consumedMessages.foldr mkConsumedMessageComplianceWitness
@@ -58,7 +58,7 @@ def Action.create'
             rcv := r.repr }
         (witness :: acc, g')
 
-    mkCreatedResourceComplianceWitness (mkCreated : Anoma.Nonce → Anoma.Resource) (consumedNonce : Anoma.Nonce) : List Anoma.ComplianceWitness × StdGen → List Anoma.ComplianceWitness × StdGen
+    mkCreatedResourceComplianceWitness (mkCreated : Anoma.Nonce → Anoma.Resource) (consumedNonce : Anoma.Nonce) : List Anoma.ComplianceWitness × StdGen → List Anoma.ComplianceWitness.{1, 1} × StdGen
       | (acc, g) =>
         let (r, g') := stdNext g
         let consumed := dummyResource consumedNonce
@@ -74,7 +74,7 @@ def Action.create'
     mkDummyComplianceWitness (nonce : Anoma.Nonce) : List Anoma.ComplianceWitness × StdGen → List Anoma.ComplianceWitness × StdGen :=
         mkCreatedResourceComplianceWitness dummyResource nonce
 
-    mkCreatedComplianceWitness (obj : CreatedObject) : List Anoma.ComplianceWitness × StdGen → List Anoma.ComplianceWitness × StdGen :=
+    mkCreatedComplianceWitness (obj : CreatedObject) : List Anoma.ComplianceWitness × StdGen → List Anoma.ComplianceWitness.{1, 1} × StdGen :=
       mkCreatedResourceComplianceWitness (fun _ => obj.toResource) ⟨obj.rand⟩
 
     mkConsumedMessageComplianceWitness (msg : SomeMessage) : List Anoma.ComplianceWitness × StdGen → List Anoma.ComplianceWitness × StdGen
@@ -111,7 +111,7 @@ def Action.create
   (ensureUnique : List Anoma.Nonce)
   (consumedMessages : List SomeMessage)
   (createdMessages : List SomeMessage)
-  : Rand (Anoma.Action × Anoma.DeltaWitness) := do
+  : Rand (Anoma.Action.{1, 1} × Anoma.DeltaWitness) := do
   let g ← get
   let (action, witness, g') := Action.create' g.down consumedObjects createdObjects ensureUnique consumedMessages createdMessages
   set (ULift.up g')

--- a/AVM/Action.lean
+++ b/AVM/Action.lean
@@ -13,11 +13,11 @@ import AVM.Message
 namespace AVM
 
 def CreatedObject.toObject (c : CreatedObject) : Object c.classId :=
-  let res : Anoma.Resource := Action.dummyResource.{0, 0} ⟨c.rand⟩
+  let res : Anoma.Resource := Action.dummyResource ⟨c.rand⟩
   let nonce := res.nullifyUniversal.nullifier.toNonce
   {uid := c.uid, nonce, data := c.data}
 
-def CreatedObject.toResource (c : CreatedObject) : Anoma.Resource.{1, 1} :=
+def CreatedObject.toResource (c : CreatedObject) : Anoma.Resource :=
   c.toObject.toResource (ephemeral := c.ephemeral)
 
 def Action.create'
@@ -27,15 +27,15 @@ def Action.create'
   (ensureUnique : List Anoma.Nonce)
   (consumedMessages : List SomeMessage)
   (createdMessages : List SomeMessage)
-  : Anoma.Action.{1, 1} × Anoma.DeltaWitness × StdGen :=
-  let (createdWitnesses, g') : List Anoma.ComplianceWitness.{1, 1} × StdGen :=
+  : Anoma.Action × Anoma.DeltaWitness × StdGen :=
+  let (createdWitnesses, g') : List Anoma.ComplianceWitness × StdGen :=
     ([], g) |>
     createdObjects.foldr mkCreatedComplianceWitness |>
     ensureUnique.foldr mkDummyComplianceWitness |>
     createdMessages.foldr mkCreatedMessageComplianceWitness
   let createdUnits : List Anoma.ComplianceUnit :=
     createdWitnesses.map Anoma.ComplianceUnit.create
-  let ((consumedWitnesses : List Anoma.ComplianceWitness.{1, 1}), g'') : List Anoma.ComplianceWitness × StdGen :=
+  let ((consumedWitnesses : List Anoma.ComplianceWitness), g'') : List Anoma.ComplianceWitness × StdGen :=
     ([], g') |>
     consumedObjects.foldr mkConsumedComplianceWitness |>
     consumedMessages.foldr mkConsumedMessageComplianceWitness
@@ -58,7 +58,7 @@ def Action.create'
             rcv := r.repr }
         (witness :: acc, g')
 
-    mkCreatedResourceComplianceWitness (mkCreated : Anoma.Nonce → Anoma.Resource) (consumedNonce : Anoma.Nonce) : List Anoma.ComplianceWitness × StdGen → List Anoma.ComplianceWitness.{1, 1} × StdGen
+    mkCreatedResourceComplianceWitness (mkCreated : Anoma.Nonce → Anoma.Resource) (consumedNonce : Anoma.Nonce) : List Anoma.ComplianceWitness × StdGen → List Anoma.ComplianceWitness × StdGen
       | (acc, g) =>
         let (r, g') := stdNext g
         let consumed := dummyResource consumedNonce
@@ -74,7 +74,7 @@ def Action.create'
     mkDummyComplianceWitness (nonce : Anoma.Nonce) : List Anoma.ComplianceWitness × StdGen → List Anoma.ComplianceWitness × StdGen :=
         mkCreatedResourceComplianceWitness dummyResource nonce
 
-    mkCreatedComplianceWitness (obj : CreatedObject) : List Anoma.ComplianceWitness × StdGen → List Anoma.ComplianceWitness.{1, 1} × StdGen :=
+    mkCreatedComplianceWitness (obj : CreatedObject) : List Anoma.ComplianceWitness × StdGen → List Anoma.ComplianceWitness × StdGen :=
       mkCreatedResourceComplianceWitness (fun _ => obj.toResource) ⟨obj.rand⟩
 
     mkConsumedMessageComplianceWitness (msg : SomeMessage) : List Anoma.ComplianceWitness × StdGen → List Anoma.ComplianceWitness × StdGen
@@ -111,7 +111,7 @@ def Action.create
   (ensureUnique : List Anoma.Nonce)
   (consumedMessages : List SomeMessage)
   (createdMessages : List SomeMessage)
-  : Rand (Anoma.Action.{1, 1} × Anoma.DeltaWitness) := do
+  : Rand (Anoma.Action × Anoma.DeltaWitness) := do
   let g ← get
   let (action, witness, g') := Action.create' g.down consumedObjects createdObjects ensureUnique consumedMessages createdMessages
   set (ULift.up g')

--- a/AVM/Action/DummyResource.lean
+++ b/AVM/Action/DummyResource.lean
@@ -22,8 +22,7 @@ private def dummyResourceLogic : Anoma.Logic.{u, v} :=
     function :=
       fun (args : Anoma.Logic.Args.{u, v}) =>
         let res : Anoma.Resource.{u, v} := args.self
-        isDummyResource res
-  }
+        isDummyResource res }
 
 /-- A dummy resource used in generated actions. -/
 def dummyResource.{u, v} (nonce : Anoma.Nonce) : Anoma.Resource.{u, v} :=

--- a/AVM/Action/DummyResource.lean
+++ b/AVM/Action/DummyResource.lean
@@ -3,33 +3,33 @@ import Anoma
 
 namespace AVM.Action
 
-private def dummyResourceLabel.{u} : ULift.{u} String :=
-  ULift.up.{u} "dummy-resource"
+private def dummyResourceLabel : ULift.{1} String :=
+  ULift.up "dummy-resource"
 
 private def dummyResourceLogicRef : Anoma.LogicRef :=
   ⟨"dummy-resource-logic"⟩
 
 /-- Checks if a resource is a dummy resource. -/
-def isDummyResource (res : Anoma.Resource.{u, v}) : Bool :=
-  res.label === dummyResourceLabel.{v} &&
+def isDummyResource (res : Anoma.Resource) : Bool :=
+  res.label === dummyResourceLabel &&
   res.logicRef == dummyResourceLogicRef &&
   res.ephemeral &&
   res.quantity == 0
 
 /-- The resource logic of any dummy resource. -/
-private def dummyResourceLogic : Anoma.Logic.{u, v} :=
+private def dummyResourceLogic : Anoma.Logic :=
   { reference := dummyResourceLogicRef,
     function :=
-      fun (args : Anoma.Logic.Args.{u, v}) =>
-        let res : Anoma.Resource.{u, v} := args.self
+      fun (args : Anoma.Logic.Args) =>
+        let res : Anoma.Resource := args.self
         isDummyResource res }
 
 /-- A dummy resource used in generated actions. -/
-def dummyResource.{u, v} (nonce : Anoma.Nonce) : Anoma.Resource.{u, v} :=
-  { Val := ⟨PUnit.{u + 1}⟩,
-    Label := ⟨ULift.{v} String⟩,
-    label := dummyResourceLabel.{v},
-    logicRef := dummyResourceLogic.{u, v}.reference,
+def dummyResource (nonce : Anoma.Nonce) : Anoma.Resource :=
+  { Val := ⟨PUnit⟩,
+    Label := ⟨ULift String⟩,
+    label := dummyResourceLabel,
+    logicRef := dummyResourceLogic.reference,
     quantity := 0,
     value := PUnit.unit,
     ephemeral := true,

--- a/AVM/Class.lean
+++ b/AVM/Class.lean
@@ -3,11 +3,11 @@ import AVM.Class.Member
 
 namespace AVM
 
-abbrev Logic.Args.{u, v} := Anoma.Logic.Args.{u, v}
+abbrev Logic.Args := Anoma.Logic.Args
 
 /-- Syntax-level object description (fields + constructors + methods) should
     desugar to the `Class` structure. -/
-structure Class {lab : Ecosystem.Label} (classId : lab.ClassId) : Type (u + 1) where
+structure Class {lab : Ecosystem.Label} (classId : lab.ClassId) : Type 2 where
   /-- The constructors of the class. -/
   constructors : (c : classId.label.ConstructorId) → Class.Constructor classId c
   /-- The destructors of the class. -/

--- a/AVM/Class/Label.lean
+++ b/AVM/Class/Label.lean
@@ -37,7 +37,7 @@ structure Label : Type 1 where
   ConstructorSignatureId : ConstructorId → Type := fun _ => Empty
   ConstructorSignatureIdEnum : (s : ConstructorId) → FinEnum (ConstructorSignatureId s)
     := by intro s; cases s <;> infer_instance
-  [constructorsFinite : FinEnum ConstructorId]
+  [constructorsEnum : FinEnum ConstructorId]
   [constructorsRepr : Repr ConstructorId]
   [constructorsBEq : BEq ConstructorId]
   [constructorsLawfulBEq : LawfulBEq ConstructorId]
@@ -47,7 +47,7 @@ structure Label : Type 1 where
   DestructorSignatureId : DestructorId → Type := fun _ => Empty
   DestructorSignatureIdEnum : (s : DestructorId) → FinEnum (DestructorSignatureId s)
     := by intro s; cases s <;> infer_instance
-  [destructorsFinite : FinEnum DestructorId]
+  [destructorsEnum : FinEnum DestructorId]
   [destructorsRepr : Repr DestructorId]
   [destructorsBEq : BEq DestructorId]
   [destructorsLawfulBEq : LawfulBEq DestructorId]
@@ -57,7 +57,7 @@ structure Label : Type 1 where
   MethodSignatureId : MethodId → Type := fun _ => Empty
   MethodSignatureIdEnum : (s : MethodId) → FinEnum (MethodSignatureId s)
     := by intro s; cases s <;> infer_instance
-  [methodsFinite : FinEnum MethodId]
+  [methodsEnum : FinEnum MethodId]
   [methodsRepr : Repr MethodId]
   [methodsBEq : BEq MethodId]
   [methodsLawfulBEq : LawfulBEq MethodId]
@@ -71,7 +71,7 @@ def Label.dummy : Label where
   DynamicLabel := default
   ConstructorId := PUnit
   ConstructorArgs := fun _ => ⟨PUnit⟩
-  constructorsFinite := inferInstanceAs (FinEnum PUnit)
+  constructorsEnum := inferInstanceAs (FinEnum PUnit)
   constructorsRepr := inferInstanceAs (Repr PUnit)
   constructorsBEq := inferInstanceAs (BEq PUnit)
   DestructorId := Empty
@@ -101,13 +101,13 @@ instance Label.MemberId.instHashable {lab : Class.Label} : Hashable (Class.Label
       mix 0
     | .methodId m =>
       mix 1
-      mix (lab.methodsFinite.equiv m)
+      mix (lab.methodsEnum.equiv m)
     | .destructorId m =>
       mix 2
-      mix (lab.destructorsFinite.equiv m)
+      mix (lab.destructorsEnum.equiv m)
     | .constructorId m =>
       mix 3
-      mix (lab.constructorsFinite.equiv m)
+      mix (lab.constructorsEnum.equiv m)
 
 instance Label.MemberId.hasBEq {lab : Class.Label} : BEq (Class.Label.MemberId lab) where
   beq a b :=

--- a/AVM/Class/Translation/Logics.lean
+++ b/AVM/Class/Translation/Logics.lean
@@ -65,6 +65,7 @@ def messageValues
     let ⟨obj, vals'⟩ := vals
     Program.messageValues (next obj) vals'
   | .return _ => []
+  | .log _ next => messageValues next vals
 
 end AVM.Program
 

--- a/AVM/Class/Translation/Logics.lean
+++ b/AVM/Class/Translation/Logics.lean
@@ -296,13 +296,12 @@ private def Member.logicFun
   -/
 private def logicFun
   {lab : Ecosystem.Label}
-  {classId : lab.ClassId}
   (eco : Ecosystem lab)
-  (cl : Class classId)
+  (classId : lab.ClassId)
   (args : Logic.Args)
   : Bool :=
   let try self : Object classId := Object.fromResource args.self
-  check cl.invariant self args
+  check eco.classes classId |>.invariant self args
   match args.status with
   | Created => true
   | Consumed =>
@@ -320,11 +319,10 @@ private def logicFun
   an object of this class. -/
 def logic
   {lab : Ecosystem.Label}
-  {classId : lab.ClassId}
   (eco : Ecosystem lab)
-  (cl : Class classId)
+  (classId : lab.ClassId)
   : Anoma.Logic :=
   { reference := classId.label.logicRef,
-    function := logicFun eco cl }
+    function := logicFun eco classId }
 
 end AVM.Class

--- a/AVM/Class/Translation/Logics.lean
+++ b/AVM/Class/Translation/Logics.lean
@@ -14,6 +14,8 @@ def trivialLogic : Anoma.Logic :=
   { reference := trivialLogicRef,
     function := fun _ => true }
 
+abbrev builtinLogics : List Anoma.Logic := [trivialLogic]
+
 end AVM.Logic
 
 namespace AVM.Program

--- a/AVM/Class/Translation/Tasks.lean
+++ b/AVM/Class/Translation/Tasks.lean
@@ -114,6 +114,7 @@ private partial def Body.tasks'
   | .return val =>
     Tasks.rands cnt fun rands =>
       cont rands.toList val adjust
+  | .log _ next => Body.tasks' cnt  adjust scope next cont
 
 private partial def Body.task'
   {α β : Type 1}

--- a/AVM/Ecosystem.lean
+++ b/AVM/Ecosystem.lean
@@ -5,6 +5,6 @@ import AVM.Ecosystem.Member
 namespace AVM
 
 /-- Ecosystem is a collection of classes. -/
-structure Ecosystem (label : Ecosystem.Label) : Type 1 where
+structure Ecosystem (label : Ecosystem.Label) : Type 2 where
   classes : (c : label.ClassId) → Class c
   multiMethods : (f : label.MultiMethodId) → Ecosystem.MultiMethod f

--- a/AVM/Ecosystem/Label/Base.lean
+++ b/AVM/Ecosystem/Label/Base.lean
@@ -30,6 +30,9 @@ structure Label : Type 1 where
   [multiMethodsBEq : BEq MultiMethodId]
   [multiMethodsLawfulBEq : LawfulBEq MultiMethodId]
 
+instance Label.instHashable : Hashable Label where
+  hash l := hash l.name
+
 instance Label.hasTypeRep : TypeRep Label where
   rep := Rep.atomic "AVM.Ecosystem.Label"
 
@@ -74,7 +77,7 @@ namespace ClassId
 def label {lab : Ecosystem.Label} (classId : lab.ClassId) : Class.Label :=
   lab.classLabel classId
 
-def MemberId {lab : Ecosystem.Label} (c : lab.ClassId) := c.label.MemberId
+abbrev MemberId {lab : Ecosystem.Label} (c : lab.ClassId) := c.label.MemberId
 
 instance MemberId.hasTypeRep {lab : Ecosystem.Label} {c : lab.ClassId} : TypeRep c.MemberId := Class.Label.MemberId.hasTypeRep c.label
 
@@ -134,6 +137,17 @@ inductive MemberId (lab : Ecosystem.Label) : Type where
   | classMember {classId : lab.ClassId} (memId : classId.MemberId)
 
 namespace MemberId
+
+instance instHashable {lab : Ecosystem.Label} : Hashable (MemberId lab) where
+  hash m := Hashable.Mix.run do
+    mix lab
+    match m with
+    | .multiMethodId f =>
+      mix 0
+      mix (lab.multiMethodsFinite.equiv f)
+    | .classMember f =>
+      mix 1
+      mix f
 
 instance instBEq {lab : Ecosystem.Label} : BEq (MemberId lab) where
   beq a b :=

--- a/AVM/Label.lean
+++ b/AVM/Label.lean
@@ -11,6 +11,13 @@ structure Object.Resource.Label where
   /-- The dynamic label is used to put dynamic data into the Resource label -/
   dynamicLabel : classId.label.DynamicLabel.Label.type
 
+instance : Hashable Object.Resource.Label where
+  hash l := Hashable.Mix.run do
+    mix l.label
+    mix (l.label.classesEnum.equiv l.classId)
+    have := l.classId.label.DynamicLabel.Label.typeHashable
+    mix l.dynamicLabel
+
 instance : TypeRep Object.Resource.Label where
   rep := Rep.atomic "Object.Resource.Label"
 
@@ -23,6 +30,15 @@ instance : BEq Object.Resource.Label where
 inductive Resource.Label : Type 1 where
   | object : Object.Resource.Label → Label
   | message : SomeMessage → Label
+
+instance : Hashable Resource.Label where
+  hash l := Hashable.Mix.run do match l with
+    | .object l =>
+      mix 0
+      mix l
+    | .message s =>
+      mix 1
+      mix s
 
 instance : TypeRep Resource.Label where
   rep := Rep.atomic "AVM.Resource.Label"

--- a/AVM/Logic.lean
+++ b/AVM/Logic.lean
@@ -7,7 +7,7 @@ import AVM.Action.DummyResource
 namespace AVM.Logic
 
 /-- Filters out dummy resources from a list of resources. -/
-def filterOutDummy (resources : List Anoma.Resource.{u, v}) : List Anoma.Resource.{u, v} :=
+def filterOutDummy (resources : List Anoma.Resource) : List Anoma.Resource :=
   resources.filter (not ∘ Action.isDummyResource)
 
 def resourceValueEq (objValue : ObjectValue) (res : Anoma.Resource) : Bool :=
@@ -37,10 +37,10 @@ def checkResourcesEphemeral (resources : List Anoma.Resource) : Bool :=
 def checkResourcesPersistent (resources : List Anoma.Resource) : Bool :=
   Logic.filterOutDummy resources |>.all Anoma.Resource.isPersistent
 
-def selectObjectResources.{u, v} (resources : List Anoma.Resource.{u, v}) : List Anoma.Resource.{u, v} :=
-  resources.filter Resource.isSomeObject.{u, v}
+def selectObjectResources (resources : List Anoma.Resource) : List Anoma.Resource :=
+  resources.filter Resource.isSomeObject
 
-def selectMessageResources.{u, v} (resources : List Anoma.Resource.{u, v}) : List Anoma.Resource.{u, v} :=
+def selectMessageResources (resources : List Anoma.Resource) : List Anoma.Resource :=
   resources.filter Resource.isSomeMessage
 
 def isObjectPreserved (obj : ObjectValue) (resources : List Anoma.Resource) : Bool :=

--- a/AVM/Message.lean
+++ b/AVM/Message.lean
@@ -16,7 +16,7 @@ def SomeMessage.toResource (msg : SomeMessage) (nonce : Anoma.Nonce) : Anoma.Res
     ephemeral := true,
     nonce }
 
-def SomeMessage.fromResource (res : Anoma.Resource.{u, v}) : Option SomeMessage :=
+def SomeMessage.fromResource (res : Anoma.Resource) : Option SomeMessage :=
   let try msg : SomeMessage := tryCast res.label
   check (msg.message.logicRef == res.logicRef)
   some msg

--- a/AVM/Message/Base.lean
+++ b/AVM/Message/Base.lean
@@ -32,6 +32,10 @@ def Message.rawSignatures {lab : Ecosystem.Label} (msg : Message lab) : List Nat
     | .constructorId m => clab.label.ConstructorSignatureIdEnum m |>.toList.map (fun s => signatures s |>.raw)
     | .upgradeId => []
 
+instance Message.instHashable (lab : Ecosystem.Label) : Hashable (Message lab) where
+  hash m := Hashable.Mix.run do
+    mix m.id
+
 instance Message.hasTypeRep (lab : Ecosystem.Label) : TypeRep (Message lab) where
   rep := Rep.composite "AVM.Message" [Rep.atomic lab.name]
 
@@ -49,6 +53,11 @@ instance Message.hasBEq {lab : Ecosystem.Label} : BEq (Message lab) where
 structure SomeMessage : Type 1 where
   {label : Ecosystem.Label}
   message : Message label
+
+instance SomeMessage.instHashable : Hashable SomeMessage where
+  hash m := Hashable.Mix.run do
+    mix m.label
+    mix m.message
 
 instance SomeMessage.hasTypeRep : TypeRep SomeMessage where
   rep := Rep.atomic "AVM.SomeMessage"

--- a/AVM/Object.lean
+++ b/AVM/Object.lean
@@ -170,7 +170,7 @@ def SomeObject.toResource
     nullifierKeyCommitment := default }
 
 /-- Converts Object to a Resource. -/
-def Object.toResource {lab : Ecosystem.Label} {c : lab.ClassId} (obj : Object c) (ephemeral : Bool) : Anoma.Resource.{1, 1}
+def Object.toResource {lab : Ecosystem.Label} {c : lab.ClassId} (obj : Object c) (ephemeral : Bool) : Anoma.Resource
  := obj.toSomeObject.toResource ephemeral
 
 def Object.fromResource
@@ -188,8 +188,8 @@ def Object.fromResource
                     privateFields := value.privateFields }
           nonce := res.nonce }
 
-def SomeObject.fromResource.{u, v}
-  (res : Anoma.Resource.{u, v})
+def SomeObject.fromResource
+  (res : Anoma.Resource)
   : Option SomeObject :=
   let try resLab : AVM.Resource.Label := tryCast res.label
   let try objLab := Resource.Label.getObjectResourceLabel resLab
@@ -200,5 +200,5 @@ def SomeObject.fromResource.{u, v}
          classId
          object }
 
-def Resource.isSomeObject.{u, v} (res : Anoma.Resource.{u, v}) : Bool :=
-  Option.isSome (SomeObject.fromResource.{u, v} res)
+def Resource.isSomeObject (res : Anoma.Resource) : Bool :=
+  Option.isSome (SomeObject.fromResource res)

--- a/AVM/Program/Parameters.lean
+++ b/AVM/Program/Parameters.lean
@@ -39,6 +39,22 @@ def Product (params : Program.Parameters) : Type :=
   | .rand rest =>
     Σ (r : Nat), Program.Parameters.Product (rest r)
 
+def Product.hashHelper {params : Program.Parameters} (p : params.Product) : Hashable.Mix := do
+  match params with
+  | .empty =>
+     mix 0
+  | .fetch _ _ =>
+     mix 1
+     mix p.fst
+     hashHelper p.snd
+  | .rand _ =>
+     mix 2
+     mix p.fst
+     hashHelper p.snd
+
+instance Product.instHashable (params : Program.Parameters) : Hashable params.Product where
+  hash p := Hashable.Mix.run (hashHelper p)
+
 private def Product.defaultValue (params : Program.Parameters) : params.Product :=
   match params with
   | .empty => PUnit.unit

--- a/AVM/Scope.lean
+++ b/AVM/Scope.lean
@@ -1,5 +1,6 @@
 import AVM.Scope.Label
 import AVM.Ecosystem
+import AVM.Class.Translation.Logics
 
 namespace AVM
 
@@ -8,3 +9,12 @@ structure Scope (lab : Scope.Label) where
 
 abbrev Ecosystem.toScope {lab : Ecosystem.Label} (eco : Ecosystem lab) : Scope lab.toScope where
   ecosystems := fun .unit => eco
+
+def Scope.logics {lab : Scope.Label} (s : Scope lab) : List Anoma.Logic :=
+  lab.EcosystemIdEnum.toList.flatMap fun e =>
+   let eco := s.ecosystems e
+   e.label.classesEnum.toList.flatMap fun c =>
+     let cl := eco.classes c
+     c.label.constructorsEnum.toList.map fun m =>
+       let ctr := cl.constructors m
+       Class.Constructor.Message.logic ctr

--- a/AVM/Scope.lean
+++ b/AVM/Scope.lean
@@ -11,6 +11,7 @@ abbrev Ecosystem.toScope {lab : Ecosystem.Label} (eco : Ecosystem lab) : Scope l
   ecosystems := fun .unit => eco
 
 def Scope.logics {lab : Scope.Label} (s : Scope lab) : List Anoma.Logic :=
+  Logic.builtinLogics ++
   lab.EcosystemIdEnum.toList.flatMap fun e =>
    let eco := s.ecosystems e
    e.label.classesEnum.toList.map fun c =>

--- a/AVM/Scope.lean
+++ b/AVM/Scope.lean
@@ -13,8 +13,5 @@ abbrev Ecosystem.toScope {lab : Ecosystem.Label} (eco : Ecosystem lab) : Scope l
 def Scope.logics {lab : Scope.Label} (s : Scope lab) : List Anoma.Logic :=
   lab.EcosystemIdEnum.toList.flatMap fun e =>
    let eco := s.ecosystems e
-   e.label.classesEnum.toList.flatMap fun c =>
-     let cl := eco.classes c
-     c.label.constructorsEnum.toList.map fun m =>
-       let ctr := cl.constructors m
-       Class.Constructor.Message.logic ctr
+   e.label.classesEnum.toList.map fun c =>
+     Class.logic eco c

--- a/AVM/Task.lean
+++ b/AVM/Task.lean
@@ -6,8 +6,8 @@ import AVM.Program.Parameters
 
 namespace AVM
 
-structure Task.Actions : Type (u + 1) where
-  actions : List Anoma.Action
+structure Task.Actions.{u, v} : Type (max u v + 1) where
+  actions : List Anoma.Action.{u, v}
   deltaWitness : Anoma.DeltaWitness
 
 /-- Tasks are intermediate data structures used in the translation. Translating
@@ -15,7 +15,7 @@ structure Task.Actions : Type (u + 1) where
   step. Tasks enable modularity of the translation – they are at the right
   level of abstraction to compose translations of different message sends,
   enabling nested method calls and subobjects. -/
-structure Task : Type 1 where
+structure Task.{u, v} : Type (max u v + 1) where
   /-- Task parameters - objects to fetch from the Anoma system and random values
     to generate. In general, values in `task.params.Product` are assumed to be
     unadjusted (see `Program.Parameters.Product`). -/
@@ -24,7 +24,7 @@ structure Task : Type 1 where
   message : params.Product → Option SomeMessage
   /-- Task actions - actions to perform parameterised by fetched objects and new
     object ids. -/
-  actions : params.Product → Rand (Option Task.Actions)
+  actions : params.Product → Rand (Option Task.Actions.{u, v})
   deriving Inhabited
 
 def Task.absorbParams (params : Program.Parameters) (task : params.Product → Task) : Task :=

--- a/AVM/Task.lean
+++ b/AVM/Task.lean
@@ -6,8 +6,8 @@ import AVM.Program.Parameters
 
 namespace AVM
 
-structure Task.Actions.{u, v} : Type (max u v + 1) where
-  actions : List Anoma.Action.{u, v}
+structure Task.Actions : Type 2 where
+  actions : List Anoma.Action
   deltaWitness : Anoma.DeltaWitness
 
 /-- Tasks are intermediate data structures used in the translation. Translating
@@ -15,7 +15,7 @@ structure Task.Actions.{u, v} : Type (max u v + 1) where
   step. Tasks enable modularity of the translation – they are at the right
   level of abstraction to compose translations of different message sends,
   enabling nested method calls and subobjects. -/
-structure Task.{u, v} : Type (max u v + 1) where
+structure Task : Type 2 where
   /-- Task parameters - objects to fetch from the Anoma system and random values
     to generate. In general, values in `task.params.Product` are assumed to be
     unadjusted (see `Program.Parameters.Product`). -/
@@ -24,7 +24,7 @@ structure Task.{u, v} : Type (max u v + 1) where
   message : params.Product → Option SomeMessage
   /-- Task actions - actions to perform parameterised by fetched objects and new
     object ids. -/
-  actions : params.Product → Rand (Option Task.Actions.{u, v})
+  actions : params.Product → Rand (Option Task.Actions)
   deriving Inhabited
 
 def Task.absorbParams (params : Program.Parameters) (task : params.Product → Task) : Task :=

--- a/AVM/Task/Translation.lean
+++ b/AVM/Task/Translation.lean
@@ -21,8 +21,6 @@ def toTransaction (task : Task) (vals : task.params.Product) : Rand (Option Anom
       { actions := acts,
         deltaProof := Anoma.Transaction.generateDeltaProof witness' acts }
 
-set_option pp.universes true
-
 private def resolveParameters (params : Program.Parameters) (cont : params.Product → Anoma.Program) : Anoma.Program :=
   match params with
   | .empty => cont PUnit.unit

--- a/AVM/Task/Translation.lean
+++ b/AVM/Task/Translation.lean
@@ -4,7 +4,7 @@ import AVM.Task
 namespace AVM.Task
 
 /-- Creates an Anoma Transaction for a given Task. -/
-def toTransaction (task : Task.{1, 1}) (vals : task.params.Product) : Rand (Option Anoma.Transaction.{1, 1}) := do
+def toTransaction (task : Task) (vals : task.params.Product) : Rand (Option Anoma.Transaction) := do
   match task.message vals with
   | none =>
     let try actions : Task.Actions ← task.actions vals
@@ -36,11 +36,11 @@ private def resolveParameters (params : Program.Parameters) (cont : params.Produ
       resolveParameters (ps objId) (fun vals => cont ⟨objId, vals⟩))
 
 /-- Creates an Anoma Program for a given Task. -/
-def toProgram (task : Task.{1, 1}) : Anoma.Program :=
+def toProgram (task : Task) : Anoma.Program :=
   let cont (vals : task.params.Product) : Anoma.Program :=
-    Anoma.Program.withRandOption.{1, 1, 1, 1} do
-      let try tx : Anoma.Transaction.{1, 1} ← task.toTransaction vals
-      pure <| Anoma.Program.submitTransaction.{1, 1, 1, 1} tx Anoma.Program.skip
+    Anoma.Program.withRandOption do
+      let try tx : Anoma.Transaction ← task.toTransaction vals
+      pure <| Anoma.Program.submitTransaction tx Anoma.Program.skip
   resolveParameters task.params cont
 
 def toProgramRand (task : Rand Task) : Anoma.Program :=

--- a/AVM/Tasks.lean
+++ b/AVM/Tasks.lean
@@ -7,10 +7,10 @@ namespace AVM
   structure of AVM programs than a single `Task`. `AVM.Program` is compiled to
   `Tasks` which are then composed into a single `Task`. The composition of
   `Tasks` collects and lifts out the parameters of all subtasks. -/
-inductive Tasks.{u, v, w} (α : Type w) : Type (max w ((max u v) + 1)) where
+inductive Tasks.{w} (α : Type w) : Type (max w 2) where
   /-- Execute a subtask and continue. The `rest` continuation receives the
     unadjusted parameter values. -/
-  | task (task : Task.{u, v}) (rest : task.params.Product → Tasks α) : Tasks α
+  | task (task : Task) (rest : task.params.Product → Tasks α) : Tasks α
   /-- Fetch an object and continue. The `rest` continuation receives the
     unadjusted original object value and is supposed to adjust it by the
     modifications to that object that occurred from the start of the program up
@@ -151,17 +151,17 @@ def coerce {α β} {tasks : Tasks α} {f : tasks.params.Product → α → β} (
     ⟨r, coerce vals'⟩
   | .result _ => vals
 
-def WithAction.{u, v} : Type (max u v + 1) := Tasks.{u, v, max u v + 1} (Rand (Option (Anoma.Action.{u, v} × Anoma.DeltaWitness)))
+def WithAction : Type 2 := Tasks (Rand (Option (Anoma.Action × Anoma.DeltaWitness)))
 
 set_option pp.universes true
 
 def composeActions
-  (tasks : WithAction.{u, v})
+  (tasks : WithAction)
   (vals : tasks.params.Product)
-  : Rand (Option Task.Actions.{u, v}) :=
+  : Rand (Option Task.Actions) :=
   match tasks with
   | .result v => do
-    let try ((action : Anoma.Action.{u, v}), witness) ← v
+    let try ((action : Anoma.Action), witness) ← v
     pure <| some { actions := [action], deltaWitness := witness }
   | .task ta rest => do
     let ⟨vals1, vals2⟩ := vals.split
@@ -206,7 +206,7 @@ def composeWithMessage
   (mkActionData : α → ActionData)
   : Task :=
   let mkAction (vals : tasks.params.Product) (a : α)
-    : Rand (Option (Anoma.Action.{1, 1} × Anoma.DeltaWitness)) :=
+    : Rand (Option (Anoma.Action × Anoma.DeltaWitness)) :=
     let actionData := mkActionData a
     let try consumedObjects := actionData.consumed.map (·.consume) |>.getSome
     let createdMessages := composeMessages tasks vals
@@ -218,7 +218,7 @@ def void {α : Type u} (tasks : Tasks α) : Tasks Unit :=
 
 def compose (tasks : Tasks Unit) : Task :=
   let mkAction (vals : tasks.params.Product) (_ : Unit)
-    : Rand (Option (Anoma.Action.{1, 1} × Anoma.DeltaWitness)) :=
+    : Rand (Option (Anoma.Action × Anoma.DeltaWitness)) :=
     let createdMessages := tasks.composeMessages vals
     Action.create [] [] [] [] createdMessages
   Tasks.composeWithAction (tasks.map' mkAction) (fun _ => none)

--- a/AVM/Tasks.lean
+++ b/AVM/Tasks.lean
@@ -153,8 +153,6 @@ def coerce {α β} {tasks : Tasks α} {f : tasks.params.Product → α → β} (
 
 def WithAction : Type 2 := Tasks (Rand (Option (Anoma.Action × Anoma.DeltaWitness)))
 
-set_option pp.universes true
-
 def composeActions
   (tasks : WithAction)
   (vals : tasks.params.Product)

--- a/Anoma.lean
+++ b/Anoma.lean
@@ -4,3 +4,4 @@ import Anoma.Logic
 import Anoma.Nullifier
 import Anoma.Transaction
 import Anoma.Program
+import Anoma.Eval

--- a/Anoma.lean
+++ b/Anoma.lean
@@ -4,4 +4,3 @@ import Anoma.Logic
 import Anoma.Nullifier
 import Anoma.Transaction
 import Anoma.Program
-import Anoma.Eval

--- a/Anoma/Action.lean
+++ b/Anoma/Action.lean
@@ -23,6 +23,6 @@ structure LogicVerifierInput : Type 1 where
   logicVKOuter : LogicVKOuterHash := ""
   proof: String := ""
 
-structure Action : Type 1 where
-  complianceUnits : List ComplianceUnit
+structure Action.{u, v} : Type (max u v + 1) where
+  complianceUnits : List ComplianceUnit.{u, v}
   logicVerifierInputs : Std.HashMap Tag LogicVerifierInput

--- a/Anoma/Action.lean
+++ b/Anoma/Action.lean
@@ -23,6 +23,6 @@ structure LogicVerifierInput : Type 1 where
   logicVKOuter : LogicVKOuterHash := ""
   proof: String := ""
 
-structure Action.{u, v} : Type (max u v + 1) where
-  complianceUnits : List ComplianceUnit.{u, v}
+structure Action : Type 2 where
+  complianceUnits : List ComplianceUnit
   logicVerifierInputs : Std.HashMap Tag LogicVerifierInput

--- a/Anoma/Compliance.lean
+++ b/Anoma/Compliance.lean
@@ -6,7 +6,7 @@ namespace Anoma
 
 abbrev MerklePath := List Nat
 
-structure ComplianceWitness : Type (max u v + 1) where
+structure ComplianceWitness.{u, v} : Type (max u v + 1) where
     consumedResource : Resource.{u, v}
     createdResource : Resource.{u, v}
     /-- Nullifier key of the consumed resource -/
@@ -22,10 +22,13 @@ structure ComplianceInstance where
 
 abbrev ComplianceProof := String
 
-structure ComplianceUnit : Type 1 where
+structure ComplianceUnit.{u, v} : Type (max u v + 1) where
   proof : ComplianceProof
   inst : ComplianceInstance
 
-def ComplianceUnit.create (_witness : ComplianceWitness) : ComplianceUnit :=
+  /-- used only by the evaluator.-/
+  witness : ComplianceWitness.{u, v}
+
+def ComplianceUnit.create (witness : ComplianceWitness.{u, v}) : ComplianceUnit.{u, v} :=
   -- This is a placeholder implementation.
-  { proof := "", inst := { } }
+  { proof := "", inst := { }, witness }

--- a/Anoma/Compliance.lean
+++ b/Anoma/Compliance.lean
@@ -6,9 +6,9 @@ namespace Anoma
 
 abbrev MerklePath := List Nat
 
-structure ComplianceWitness.{u, v} : Type (max u v + 1) where
-    consumedResource : Resource.{u, v}
-    createdResource : Resource.{u, v}
+structure ComplianceWitness : Type 2 where
+    consumedResource : Resource
+    createdResource : Resource
     /-- Nullifier key of the consumed resource -/
     nfKey : NullifierKey
     /-- Random scalar for delta commitment -/
@@ -22,13 +22,13 @@ structure ComplianceInstance where
 
 abbrev ComplianceProof := String
 
-structure ComplianceUnit.{u, v} : Type (max u v + 1) where
+structure ComplianceUnit : Type 2 where
   proof : ComplianceProof
   inst : ComplianceInstance
 
   /-- used only by the evaluator.-/
-  witness : ComplianceWitness.{u, v}
+  witness : ComplianceWitness
 
-def ComplianceUnit.create (witness : ComplianceWitness.{u, v}) : ComplianceUnit.{u, v} :=
+def ComplianceUnit.create (witness : ComplianceWitness) : ComplianceUnit :=
   -- This is a placeholder implementation.
   { proof := "", inst := { }, witness }

--- a/Anoma/Eval.lean
+++ b/Anoma/Eval.lean
@@ -1,0 +1,162 @@
+import Prelude
+import Anoma.Resource
+import Anoma.Program
+import Anoma.Logic
+import Anoma.Transaction
+import AVM.Object
+import Mathlib.Control.Random
+
+namespace Anoma.Program
+
+structure RmState.{u, v} : Type (max u v + 1) where
+  gen : StdGen
+  objects : Std.HashMap ObjectId Resource.{u, v}
+  commited : Std.HashSet Commitment
+  nullified : Std.HashSet Resource.{u, v}
+  logics : Std.HashMap LogicRef LogicFunction.{u, v}
+
+  logs : List String
+
+abbrev RmState.ini (logics : Std.HashMap LogicRef LogicFunction) (gen : StdGen := mkStdGen 0) : RmState :=
+  { gen
+    objects := ∅
+    nullified := ∅
+    commited := ∅
+    logics
+    logs := ∅ }
+
+/-- The evaluation monad -/
+abbrev RunM.{u, v} (a : Type (max u v + 1)) : Type (max u v + 1) :=
+  EStateM (ULift Program.Error) (ULift RmState.{u, v}) a
+
+def modify' (f : RmState → RmState) : RunM PUnit :=
+  modify (fun s => ULift.up (f s.down))
+
+def get'.{u, v} : RunM.{u, v} RmState.{u, v} :=
+  (·.down) <$> get
+
+def set' (s : RmState) : RunM PUnit :=
+  set (ULift.up s)
+
+def throw' {α : Type _} (e : Program.Error) : RunM α :=
+  throw (ULift.up e)
+
+/-- checks that consumed and created resources of the same kind are balanced -/
+def checkDelta.{u, v} (consumed created : List Resource.{u, v}) : RunM PUnit := do
+  let mkMap (l : List Resource.{u, v}) : Std.HashMap Resource.Kind.{v} (List Resource.{u, v}) := l.groupByKey (·.kind)
+  let consumedByKind := mkMap consumed
+  let createdByKind := mkMap created
+  let kinds : Std.HashSet Resource.Kind.{v} := Std.HashSet.ofList (consumedByKind.keys ++ createdByKind.keys)
+  let getQuantityOfKind (m : Std.HashMap Resource.Kind.{v} (List Resource.{u, v})) (k : Resource.Kind.{v}) : Nat :=
+    m.get? k |>.getD [] |>.map (·.quantity) |>.sum
+  for kind in kinds do
+    let numConsumed := getQuantityOfKind consumedByKind kind
+    let numCreated := getQuantityOfKind createdByKind kind
+    if numConsumed == numCreated
+    then pure .unit
+    -- else throw' (.balanceCheck s!"numConsumed: {numConsumed}/{consumed.length}, numCreated: {numCreated}/{created.length}")
+    else pure .unit
+
+def picks {A : Type u} (l : List A) : List (A × List A) :=
+  List.finRange l.length |>.map (fun i => ⟨l.get i, l.eraseIdx i⟩)
+
+def fetchLogic.{u, v} (ref : LogicRef) : RunM.{u, v} (LogicFunction.{u, v}) := do
+  let s <- get'
+  match s.logics.get? ref with
+  | none => throw' (.missingLogic ref)
+  | some s => pure s
+
+def storeLogic (ref : LogicRef) (f : LogicFunction) := do
+  modify' (fun s => {s with logics := s.logics.insert ref f})
+
+def storeCreated (created : List Resource) : RunM PUnit := do
+  let created := created.filter (·.ephemeral.not)
+  for r in created do
+    dbgTrace s!"created" (fun _ =>
+    let try val : AVM.Object.Resource.SomeValue := tryCast r.value
+    dbgTrace s!"hi: {val.uid}" (fun _ =>
+    modify' (fun s => {s with objects := s.objects.insert val.uid r
+                              commited := s.commited.insert r.commitment})))
+
+def runAction (a : Action) : RunM PUnit := do
+  let units : List ComplianceUnit := a.complianceUnits
+  let witnesses : List ComplianceWitness := units.map (·.witness)
+  let consumed : List Resource := witnesses.map (·.consumedResource)
+  let created : List Resource := witnesses.map (·.createdResource)
+  let createdPicks := picks created
+  let consumedPicks := picks consumed
+  let checkLogic
+        (self : Resource)
+        (status : ConsumedCreated)
+        (consumed' created' : List Resource) : RunM PUnit
+        := do
+        let args : Logic.Args :=
+          { self
+            status
+            consumed := consumed'
+            created := created'
+            Data := ⟨Unit⟩
+            data := .unit }
+        let logic <- fetchLogic self.logicRef
+        if logic args
+        then pure .unit
+        else throw' .logicFailed
+  checkDelta consumed created
+  for (r, consumed') in consumedPicks do
+    checkLogic r .Consumed consumed' created
+  for (r, created') in createdPicks do
+    checkLogic r .Created consumed created'
+  storeCreated created
+  -- TODO nullify consumed
+
+def logmsg (msg : String) : RunM PUnit :=
+  modify' (fun s => {s with logs := s.logs.cons msg})
+
+def runTransaction (t : Transaction) : RunM PUnit := do
+  let actions : List Action := t.actions
+  logmsg "runtrans2"
+  for action in actions do
+    runAction action
+
+partial
+def interpret : Program → RunM PUnit
+  | .skip => pure .unit
+  | .raise err => throw' err
+  | .log msg next => do
+    modify' (fun s => {s with logs := s.logs.cons msg})
+    interpret next
+  | .tryCatch b handle next =>
+      try do
+        interpret b
+        interpret next
+      catch err => interpret (handle (ULift.down err))
+  | .queryResource q next => do
+    let s ← get
+    match s.down.objects.get? q.uid with
+    | .none => throw' (.storageError s!"object {q.uid} not in storage")
+    | .some r => interpret (next r)
+  | .submitTransaction t next => do
+    runTransaction t
+    interpret next
+  | .withRandomGen next => do
+    let s ← get'
+    let ⟨gen1, gen2⟩ := stdSplit s.gen
+    set' {s with gen := gen1}
+    next gen2 |>.interpret
+
+def eval (logics : Std.HashMap LogicRef Anoma.LogicFunction) (p : Program) : EStateM.Result (ULift Program.Error) (ULift RmState) PUnit :=
+  interpret p |>.run (ULift.up (RmState.ini logics))
+
+def run (logics : Std.HashMap LogicRef Anoma.LogicFunction) (p : Program) : IO Unit := do
+  let printLogs (logs : List String) : IO Unit := do
+    if logs.isEmpty then IO.println "<no logs>" else pure Unit.unit
+    for log in logs do
+      IO.println log
+  match eval logics p with
+  | .ok _res s => do
+    printLogs s.down.logs
+    IO.println "success"
+  | .error err s => do
+    printLogs s.down.logs
+    IO.println "error"
+    IO.println (repr err.down)

--- a/Anoma/Eval.lean
+++ b/Anoma/Eval.lean
@@ -9,12 +9,12 @@ import Mathlib.Control.Random
 
 namespace Anoma.Program
 
-structure RmState.{u, v} : Type (max u v + 1) where
+structure RmState : Type 2 where
   gen : StdGen
-  objects : Std.HashMap ObjectId Resource.{u, v}
+  objects : Std.HashMap ObjectId Resource
   commited : Std.HashSet Commitment
-  nullified : Std.HashSet Resource.{u, v}
-  logics : Std.HashMap LogicRef LogicFunction.{u, v}
+  nullified : Std.HashSet Resource
+  logics : Std.HashMap LogicRef LogicFunction
 
   logs : List String
 
@@ -26,29 +26,26 @@ abbrev RmState.ini (logics : Std.HashMap LogicRef LogicFunction) (gen : StdGen :
     logics
     logs := ∅ }
 
+abbrev RunM (a : Type 2) : Type 2 :=
+  EStateM (ULift Program.Error) RmState a
+
 /-- The evaluation monad -/
-abbrev RunM.{u, v} (a : Type (max u v + 1)) : Type (max u v + 1) :=
-  EStateM (ULift Program.Error) (ULift RmState.{u, v}) a
+def modify' (f : RmState → RmState) : RunM PUnit := modify (fun s => f s)
 
-def modify' (f : RmState → RmState) : RunM PUnit :=
-  modify (fun s => ULift.up (f s.down))
+def get' : RunM RmState := get
 
-def get'.{u, v} : RunM.{u, v} RmState.{u, v} :=
-  (·.down) <$> get
-
-def set' (s : RmState) : RunM PUnit :=
-  set (ULift.up s)
+def set' (s : RmState) : RunM PUnit := set s
 
 def throw' {α : Type _} (e : Program.Error) : RunM α :=
   throw (ULift.up e)
 
 /-- checks that consumed and created resources of the same kind are balanced -/
-def checkDelta.{u, v} (consumed created : List Resource.{u, v}) : RunM PUnit := do
-  let mkMap (l : List Resource.{u, v}) : Std.HashMap Resource.Kind.{v} (List Resource.{u, v}) := l.groupByKey (·.kind)
+def checkDelta (consumed created : List Resource) : RunM PUnit := do
+  let mkMap (l : List Resource) : Std.HashMap Resource.Kind (List Resource) := l.groupByKey (·.kind)
   let consumedByKind := mkMap consumed
   let createdByKind := mkMap created
-  let kinds : Std.HashSet Resource.Kind.{v} := Std.HashSet.ofList (consumedByKind.keys ++ createdByKind.keys)
-  let getQuantityOfKind (m : Std.HashMap Resource.Kind.{v} (List Resource.{u, v})) (k : Resource.Kind.{v}) : Nat :=
+  let kinds : Std.HashSet Resource.Kind := Std.HashSet.ofList (consumedByKind.keys ++ createdByKind.keys)
+  let getQuantityOfKind (m : Std.HashMap Resource.Kind (List Resource)) (k : Resource.Kind) : Nat :=
     m.get? k |>.getD [] |>.map (·.quantity) |>.sum
   for kind in kinds do
     let numConsumed := getQuantityOfKind consumedByKind kind
@@ -62,8 +59,8 @@ def checkDelta.{u, v} (consumed created : List Resource.{u, v}) : RunM PUnit := 
 def picks {A : Type u} (l : List A) : List (A × List A) :=
   List.finRange l.length |>.map (fun i => ⟨l.get i, l.eraseIdx i⟩)
 
-def fetchLogic.{u, v} (ref : LogicRef) : RunM.{u, v} (LogicFunction.{u, v}) := do
-  let s <- get'
+def fetchLogic (ref : LogicRef) : RunM (LogicFunction) := do
+  let s <- get
   match s.logics.get? ref with
   | none => throw' (.missingLogic ref)
   | some s => pure s
@@ -134,7 +131,7 @@ def interpret : Program → RunM PUnit
       catch err => interpret (handle (ULift.down err))
   | .queryResource q next => do
     let s ← get
-    match s.down.objects.get? q.uid with
+    match s.objects.get? q.uid with
     | .none => throw' (.storageError s!"object {q.uid} not in storage")
     | .some r => interpret (next r)
   | .submitTransaction t next => do
@@ -146,9 +143,9 @@ def interpret : Program → RunM PUnit
     set' {s with gen := gen1}
     next gen2 |>.interpret
 
-def eval {lab : AVM.Scope.Label} (scope : AVM.Scope lab) (p : Program) : EStateM.Result (ULift Program.Error) (ULift RmState) PUnit :=
+def eval {lab : AVM.Scope.Label} (scope : AVM.Scope lab) (p : Program) : EStateM.Result (ULift Program.Error) RmState PUnit :=
   let logics := Std.HashMap.ofList (scope.logics.map fun l => ⟨l.reference, l.function⟩)
-  interpret p |>.run (ULift.up (RmState.ini logics))
+  interpret p |>.run (RmState.ini logics)
 
 def run {lab : AVM.Scope.Label} (scope : AVM.Scope lab) (p : Program) : IO Unit := do
   let printLogs (logs : List String) : IO Unit := do
@@ -157,9 +154,9 @@ def run {lab : AVM.Scope.Label} (scope : AVM.Scope lab) (p : Program) : IO Unit 
       IO.println log
   match eval scope p with
   | .ok _res s => do
-    printLogs s.down.logs
+    printLogs s.logs
     IO.println "success"
   | .error err s => do
-    printLogs s.down.logs
+    printLogs s.logs
     IO.println "error"
     IO.println (repr err.down)

--- a/Anoma/Eval.lean
+++ b/Anoma/Eval.lean
@@ -4,6 +4,7 @@ import Anoma.Program
 import Anoma.Logic
 import Anoma.Transaction
 import AVM.Object
+import AVM.Scope
 import Mathlib.Control.Random
 
 namespace Anoma.Program
@@ -54,6 +55,7 @@ def checkDelta.{u, v} (consumed created : List Resource.{u, v}) : RunM PUnit := 
     let numCreated := getQuantityOfKind createdByKind kind
     if numConsumed == numCreated
     then pure .unit
+    -- TODO uncomment
     -- else throw' (.balanceCheck s!"numConsumed: {numConsumed}/{consumed.length}, numCreated: {numCreated}/{created.length}")
     else pure .unit
 
@@ -144,15 +146,16 @@ def interpret : Program → RunM PUnit
     set' {s with gen := gen1}
     next gen2 |>.interpret
 
-def eval (logics : Std.HashMap LogicRef Anoma.LogicFunction) (p : Program) : EStateM.Result (ULift Program.Error) (ULift RmState) PUnit :=
+def eval {lab : AVM.Scope.Label} (scope : AVM.Scope lab) (p : Program) : EStateM.Result (ULift Program.Error) (ULift RmState) PUnit :=
+  let logics := Std.HashMap.ofList (scope.logics.map fun l => ⟨l.reference, l.function⟩)
   interpret p |>.run (ULift.up (RmState.ini logics))
 
-def run (logics : Std.HashMap LogicRef Anoma.LogicFunction) (p : Program) : IO Unit := do
+def run {lab : AVM.Scope.Label} (scope : AVM.Scope lab) (p : Program) : IO Unit := do
   let printLogs (logs : List String) : IO Unit := do
     if logs.isEmpty then IO.println "<no logs>" else pure Unit.unit
     for log in logs do
       IO.println log
-  match eval logics p with
+  match eval scope p with
   | .ok _res s => do
     printLogs s.down.logs
     IO.println "success"

--- a/Anoma/Logic.lean
+++ b/Anoma/Logic.lean
@@ -2,7 +2,7 @@ import Anoma.Resource
 
 namespace Anoma
 
-structure Logic.Args.{u, v} where
+structure Logic.Args.{u, v} : Type (max u v + 1) where
   self : Resource.{u, v}
   status : ConsumedCreated
   consumed : List Resource.{u, v}
@@ -13,6 +13,8 @@ structure Logic.Args.{u, v} where
 
 def Logic.Args.isConsumed (d : Logic.Args) := d.status.isConsumed
 
+abbrev LogicFunction.{u, v} : Type (max u v + 1) := Logic.Args.{u, v} → Bool
+
 structure Logic.{u, v} where
   reference : LogicRef
-  function : Logic.Args.{u, v} → Bool
+  function : LogicFunction.{u, v}

--- a/Anoma/Logic.lean
+++ b/Anoma/Logic.lean
@@ -2,19 +2,19 @@ import Anoma.Resource
 
 namespace Anoma
 
-structure Logic.Args.{u, v} : Type (max u v + 1) where
-  self : Resource.{u, v}
+structure Logic.Args : Type 2 where
+  self : Resource
   status : ConsumedCreated
-  consumed : List Resource.{u, v}
-  created : List Resource.{u, v}
+  consumed : List Resource
+  created : List Resource
   /-- `data` is the action's appData for self -/
   Data : SomeType.{0}
   data : Data.type
 
 def Logic.Args.isConsumed (d : Logic.Args) := d.status.isConsumed
 
-abbrev LogicFunction.{u, v} : Type (max u v + 1) := Logic.Args.{u, v} → Bool
+abbrev LogicFunction : Type 2 := Logic.Args → Bool
 
-structure Logic.{u, v} where
+structure Logic where
   reference : LogicRef
-  function : LogicFunction.{u, v}
+  function : LogicFunction

--- a/Anoma/Nonce.lean
+++ b/Anoma/Nonce.lean
@@ -6,7 +6,7 @@ namespace Anoma
 
 structure Nonce where
  value : Nat
- deriving BEq
+ deriving BEq, Hashable
 
 instance Nonce.hasTypeRep : TypeRep Nonce where
   rep := Rep.atomic "Nonce"

--- a/Anoma/NullifierKey.lean
+++ b/Anoma/NullifierKey.lean
@@ -43,4 +43,4 @@ def checkNullifierKey (key : NullifierKey) (nfc : NullifierKeyCommitment) : Deci
 def NullifierKey.commitment (k : NullifierKey) : NullifierKeyCommitment :=
   match k with
   | .universal => .universal
-  | (.secret s) => .ofSecret s
+  | .secret s => .ofSecret s

--- a/Anoma/Program.lean
+++ b/Anoma/Program.lean
@@ -1,5 +1,6 @@
 import Prelude
 import Anoma.Resource
+import Anoma.Logic
 import Anoma.Transaction
 import Anoma.Identities
 import Mathlib.Control.Random
@@ -14,18 +15,18 @@ inductive StorageValue where
   | bool (b : Bool)
   | bytes (b : ByteArray)
 
-inductive Program.ResourceQuery where
-  | queryByObjectId (uid : ObjectId)
+structure Program.ResourceQuery where
+  uid : ObjectId
 
-inductive Program.Error where
-  | networkError (msg : String)
-  | engineError (msg : String)
-  | decryptionError (msg : String)
-  | commitmentError (msg : String)
+inductive Program.Error : Type where
   | identityError (msg : String)
   | storageError (msg : String)
+  | logicFailed
+  | missingLogic (ref : LogicRef)
+  | balanceCheck (msg : String)
   | typeError (msg : String)
   | userError
+  deriving Repr
 
 /-- Represents an Anoma program, as per
   https://forum.anoma.net/t/reifying-the-local-domain-solver-and-controller-in-the-avm
@@ -34,33 +35,33 @@ inductive Program where
   | skip
   | raise (err : Program.Error)
   | tryCatch (prog : Program) (onError : Program.Error → Program) (next : Program)
-  | withRandomGen (next : StdGen → Program × StdGen)
+  | withRandomGen (next : StdGen → Program)
   | queryResource (query : Program.ResourceQuery) (next : Resource → Program)
   | submitTransaction (tx : Transaction) (next : Program)
-  | decrypt (engine : EngineId) (data : Ciphertext) (next : Plaintext → Program)
-  | requestCommitment (engine : EngineId) (data : Signable) (next : Commitment → Program)
-  | generateIdentity (backend : Backend) (params : IDParams) (capabilities : Capabilities)
-      (next : (commitmentEngine : Option EngineId) → (decryptionEngine : Option EngineId) → (externalIdentity : EngineId) → Program)
-  | connectIdentity (externalIdentity : EngineId) (backend : Backend) (capabilities : Capabilities)
-      (next : (commitmentEngine : Option EngineId) → (decryptionEngine : Option EngineId) → Program)
-  | deleteIdentity (externalIdentity : EngineId) (backend : Backend) (next : Program)
-  | getValue (key : StorageKey) (next : Option StorageValue → Program)
-  | setValue (key : StorageKey) (value : StorageValue) (next : Program)
-  | deleteValue (key : StorageKey) (next : Program)
+  | log (msg : String) (next : Program)
+  -- | decrypt (engine : EngineId) (data : Ciphertext) (next : Plaintext → Program)
+  -- | requestCommitment (engine : EngineId) (data : Signable) (next : Commitment → Program)
+  -- | generateIdentity (backend : Backend) (params : IDParams) (capabilities : Capabilities)
+  --     (next : (commitmentEngine : Option EngineId) → (decryptionEngine : Option EngineId) → (externalIdentity : EngineId) → Program)
+  -- | connectIdentity (externalIdentity : EngineId) (backend : Backend) (capabilities : Capabilities)
+  --     (next : (commitmentEngine : Option EngineId) → (decryptionEngine : Option EngineId) → Program)
+  -- | deleteIdentity (externalIdentity : EngineId) (backend : Backend) (next : Program)
+  -- | getValue (key : StorageKey) (next : Option StorageValue → Program)
+  -- | setValue (key : StorageKey) (value : StorageValue) (next : Program)
+  -- | deleteValue (key : StorageKey) (next : Program)
 
 def Program.genObjectId (next : ObjectId → Program) : Program :=
   Program.withRandomGen fun g =>
-    let (objId, g') := stdNext g
-    (next objId, g')
+    let objId := stdNext g |>.fst
+    next objId
 
 def Program.withRand (prog : Rand Program) : Program :=
   Program.withRandomGen fun g =>
-    let (next, g') := prog.run (ULift.up g)
-    (next, ULift.down g')
+    prog.run' (ULift.up g)
 
 def Program.withRandOption (prog : Rand (Option Program)) : Program :=
   Program.withRandomGen fun g =>
-    let (next?, g') := prog.run (ULift.up g)
+    let next? := prog.run' (ULift.up g)
     match next? with
-    | none => (Program.raise Program.Error.userError, ULift.down g')
-    | some next => (next, ULift.down g')
+    | none => Program.raise Program.Error.userError
+    | some next => next

--- a/Anoma/Program.lean
+++ b/Anoma/Program.lean
@@ -31,13 +31,13 @@ inductive Program.Error : Type where
 /-- Represents an Anoma program, as per
   https://forum.anoma.net/t/reifying-the-local-domain-solver-and-controller-in-the-avm
   -/
-inductive Program where
+inductive Program.{u, v, x, y} where
   | skip
   | raise (err : Program.Error)
   | tryCatch (prog : Program) (onError : Program.Error → Program) (next : Program)
   | withRandomGen (next : StdGen → Program)
-  | queryResource (query : Program.ResourceQuery) (next : Resource → Program)
-  | submitTransaction (tx : Transaction) (next : Program)
+  | queryResource (query : Program.ResourceQuery) (next : Resource.{u, v} → Program)
+  | submitTransaction (tx : Transaction.{x, y}) (next : Program)
   | log (msg : String) (next : Program)
   -- | decrypt (engine : EngineId) (data : Ciphertext) (next : Plaintext → Program)
   -- | requestCommitment (engine : EngineId) (data : Signable) (next : Commitment → Program)

--- a/Anoma/Program.lean
+++ b/Anoma/Program.lean
@@ -39,16 +39,6 @@ inductive Program : Type 2 where
   | queryResource (query : Program.ResourceQuery) (next : Resource → Program)
   | submitTransaction (tx : Transaction) (next : Program)
   | log (msg : String) (next : Program)
-  -- | decrypt (engine : EngineId) (data : Ciphertext) (next : Plaintext → Program)
-  -- | requestCommitment (engine : EngineId) (data : Signable) (next : Commitment → Program)
-  -- | generateIdentity (backend : Backend) (params : IDParams) (capabilities : Capabilities)
-  --     (next : (commitmentEngine : Option EngineId) → (decryptionEngine : Option EngineId) → (externalIdentity : EngineId) → Program)
-  -- | connectIdentity (externalIdentity : EngineId) (backend : Backend) (capabilities : Capabilities)
-  --     (next : (commitmentEngine : Option EngineId) → (decryptionEngine : Option EngineId) → Program)
-  -- | deleteIdentity (externalIdentity : EngineId) (backend : Backend) (next : Program)
-  -- | getValue (key : StorageKey) (next : Option StorageValue → Program)
-  -- | setValue (key : StorageKey) (value : StorageValue) (next : Program)
-  -- | deleteValue (key : StorageKey) (next : Program)
 
 def Program.genObjectId (next : ObjectId → Program) : Program :=
   Program.withRandomGen fun g =>

--- a/Anoma/Program.lean
+++ b/Anoma/Program.lean
@@ -21,7 +21,7 @@ structure Program.ResourceQuery where
 inductive Program.Error : Type where
   | identityError (msg : String)
   | storageError (msg : String)
-  | logicFailed
+  | logicFailed (logRef : LogicRef)
   | missingLogic (ref : LogicRef)
   | balanceCheck (msg : String)
   | typeError (msg : String)

--- a/Anoma/Program.lean
+++ b/Anoma/Program.lean
@@ -31,13 +31,13 @@ inductive Program.Error : Type where
 /-- Represents an Anoma program, as per
   https://forum.anoma.net/t/reifying-the-local-domain-solver-and-controller-in-the-avm
   -/
-inductive Program.{u, v, x, y} where
+inductive Program : Type 2 where
   | skip
   | raise (err : Program.Error)
   | tryCatch (prog : Program) (onError : Program.Error → Program) (next : Program)
   | withRandomGen (next : StdGen → Program)
-  | queryResource (query : Program.ResourceQuery) (next : Resource.{u, v} → Program)
-  | submitTransaction (tx : Transaction.{x, y}) (next : Program)
+  | queryResource (query : Program.ResourceQuery) (next : Resource → Program)
+  | submitTransaction (tx : Transaction) (next : Program)
   | log (msg : String) (next : Program)
   -- | decrypt (engine : EngineId) (data : Ciphertext) (next : Plaintext → Program)
   -- | requestCommitment (engine : EngineId) (data : Signable) (next : Commitment → Program)

--- a/Anoma/Resource.lean
+++ b/Anoma/Resource.lean
@@ -8,21 +8,61 @@ namespace Anoma
 
 structure LogicRef where
   ref : String
-  deriving BEq, Repr, Inhabited
+  deriving BEq, Repr, Inhabited, Hashable
 
 /-- Representation of Anoma Resource data. -/
 structure Resource.{u, v} : Type (max u v + 1) where
-  Val : SomeType.{u}
   Label : SomeType.{v}
   label : Label.type
+  Val : SomeType.{u}
+  value : Val.type
   logicRef : LogicRef
   quantity : Nat
-  value : Val.type
   ephemeral : Bool
   nonce : Nonce
   nullifierKeyCommitment : NullifierKeyCommitment
 
-instance Resource.instBEq : BEq Resource where
+namespace Resource
+
+instance instHashable : Hashable Resource where
+  hash r :=
+    Hashable.Mix.run do
+      have := r.Label.typeHashable
+      have := r.Val.typeHashable
+      mix r.value
+      mix r.label
+      mix r.logicRef
+      mix r.logicRef
+      mix r.quantity
+      mix r.ephemeral
+      mix r.nonce
+      mix r.nullifierKeyCommitment
+
+structure Kind.{v} : Type (v + 1) where
+  Label : SomeType.{v}
+  label : Label.type
+  logicRef : LogicRef
+
+def kind (r : Resource) : Kind where
+  Label := r.Label
+  label := r.label
+  logicRef := r.logicRef
+
+namespace Kind
+
+  instance instBEq : BEq Kind where
+    beq a b := a.label === b.label
+      && a.logicRef == b.logicRef
+
+  instance instHashable : Hashable Kind where
+    hash a := Hashable.Mix.run do
+      have := a.Label.typeHashable
+      mix a.label
+      mix a.logicRef
+
+end Kind
+
+instance instBEq : BEq Resource where
   beq a b := a.label === b.label
     && a.logicRef == b.logicRef
     && a.quantity == b.quantity
@@ -31,11 +71,13 @@ instance Resource.instBEq : BEq Resource where
     && a.nonce === b.nonce
     && a.nullifierKeyCommitment === b.nullifierKeyCommitment
 
-def Resource.isEphemeral (r : Resource) : Bool :=
+def isEphemeral (r : Resource) : Bool :=
   r.ephemeral
 
-def Resource.isPersistent (r : Resource) : Bool :=
+def isPersistent (r : Resource) : Bool :=
   not r.isEphemeral
+
+end Resource
 
 /-- A proof that `key` can nullify the resources `res` -/
 structure CanNullifyResource (key : NullifierKey) (res : Resource) : Prop where
@@ -59,7 +101,6 @@ def Resource.nullifyUniversal (res : Resource)
   rw [p1]
   constructor
 
-/-- Computes the commitment of a Resource -/
-def Resource.commitment (_r : Resource) : Commitment :=
-  -- TODO: Replace with proper serialization and hashing of all relevant fields
-  Signature.ed25519Signature "dummy"
+/-- Computes the commitment of a Resource (mock implementation). -/
+def Resource.commitment (r : Resource) : Commitment :=
+  Signature.ed25519Signature s!"{hash r}"

--- a/Anoma/Resource.lean
+++ b/Anoma/Resource.lean
@@ -11,10 +11,10 @@ structure LogicRef where
   deriving BEq, Repr, Inhabited, Hashable
 
 /-- Representation of Anoma Resource data. -/
-structure Resource.{u, v} : Type (max u v + 1) where
-  Label : SomeType.{v}
+structure Resource : Type 2 where
+  Label : SomeType.{1}
   label : Label.type
-  Val : SomeType.{u}
+  Val : SomeType.{1}
   value : Val.type
   logicRef : LogicRef
   quantity : Nat

--- a/Anoma/Resource.lean
+++ b/Anoma/Resource.lean
@@ -32,7 +32,6 @@ instance instHashable : Hashable Resource where
       mix r.value
       mix r.label
       mix r.logicRef
-      mix r.logicRef
       mix r.quantity
       mix r.ephemeral
       mix r.nonce

--- a/Anoma/Simulator.lean
+++ b/Anoma/Simulator.lean
@@ -152,3 +152,4 @@ def run {lab : AVM.Scope.Label} (scope : AVM.Scope lab) (p : Program) : IO Unit 
     printLogs s.logs
     IO.println "error"
     IO.println (repr err.down)
+    IO.Process.exit 1

--- a/Anoma/Simulator.lean
+++ b/Anoma/Simulator.lean
@@ -12,7 +12,7 @@ namespace Anoma.Program
 structure RmState : Type 2 where
   gen : StdGen
   objects : Std.HashMap ObjectId Resource
-  commited : Std.HashSet Commitment
+  committed : Std.HashSet Commitment
   nullified : Std.HashSet Resource
   logics : Std.HashMap LogicRef LogicFunction
 
@@ -22,7 +22,7 @@ abbrev RmState.ini (logics : Std.HashMap LogicRef LogicFunction) (gen : StdGen :
   { gen
     objects := ∅
     nullified := ∅
-    commited := ∅
+    committed := ∅
     logics
     logs := ∅ }
 
@@ -67,7 +67,7 @@ def storeCreated (created : List Resource) : RunM PUnit := do
     let try val : AVM.Object.Resource.SomeValue := tryCast r.value
     dbgTrace s!"hi: {val.uid}" (fun _ =>
     modify (fun s => {s with objects := s.objects.insert val.uid r
-                             commited := s.commited.insert r.commitment})))
+                             committed := s.committed.insert r.commitment})))
 
 def runAction (a : Action) : RunM PUnit := do
   let units : List ComplianceUnit := a.complianceUnits

--- a/Anoma/Simulator.lean
+++ b/Anoma/Simulator.lean
@@ -18,6 +18,10 @@ structure RmState : Type 2 where
 
   logs : List String
 
+structure SplitAction : Type 3 where
+  consumed : List Resource
+  created : List Resource
+
 abbrev RmState.ini (logics : Std.HashMap LogicRef LogicFunction) (gen : StdGen := mkStdGen 0) : RmState :=
   { gen
     objects := ∅
@@ -34,7 +38,9 @@ def throw' {α : Type _} (e : Program.Error) : RunM α :=
   throw (ULift.up e)
 
 /-- checks that consumed and created resources of the same kind are balanced -/
-def checkDelta (consumed created : List Resource) : RunM PUnit := do
+def checkDelta (actions : List SplitAction) : RunM PUnit := do
+  let consumed := actions.flatMap (·.consumed)
+  let created := actions.flatMap (·.created)
   let mkMap (l : List Resource) : Std.HashMap Resource.Kind (List Resource) := l.groupByKey (·.kind)
   let consumedByKind := mkMap consumed
   let createdByKind := mkMap created
@@ -69,11 +75,17 @@ def storeCreated (created : List Resource) : RunM PUnit := do
     modify (fun s => {s with objects := s.objects.insert val.uid r
                              committed := s.committed.insert r.commitment})))
 
-def runAction (a : Action) : RunM PUnit := do
+
+def Action.split (a : Action) : SplitAction :=
   let units : List ComplianceUnit := a.complianceUnits
   let witnesses : List ComplianceWitness := units.map (·.witness)
-  let consumed : List Resource := witnesses.map (·.consumedResource)
-  let created : List Resource := witnesses.map (·.createdResource)
+  { consumed := witnesses.map (·.consumedResource)
+    created := witnesses.map (·.createdResource) }
+
+
+def runAction (a : SplitAction) : RunM PUnit := do
+  let consumed : List Resource := a.consumed
+  let created : List Resource := a.created
   let createdPicks := picks created
   let consumedPicks := picks consumed
   let checkLogic
@@ -91,8 +103,7 @@ def runAction (a : Action) : RunM PUnit := do
         let logic <- fetchLogic self.logicRef
         if logic args
         then pure .unit
-        else throw' .logicFailed
-  checkDelta consumed created
+        else throw' (.logicFailed)
   for (r, consumed') in consumedPicks do
     checkLogic r .Consumed consumed' created
   for (r, created') in createdPicks do
@@ -104,8 +115,8 @@ def logmsg (msg : String) : RunM PUnit :=
   modify (fun s => {s with logs := s.logs.cons msg})
 
 def runTransaction (t : Transaction) : RunM PUnit := do
-  let actions : List Action := t.actions
-  logmsg "runtrans2"
+  let actions : List SplitAction := t.actions |>.map Action.split
+  checkDelta actions
   for action in actions do
     runAction action
 

--- a/Anoma/Simulator.lean
+++ b/Anoma/Simulator.lean
@@ -26,15 +26,9 @@ abbrev RmState.ini (logics : Std.HashMap LogicRef LogicFunction) (gen : StdGen :
     logics
     logs := ∅ }
 
+/-- The evaluation monad -/
 abbrev RunM (a : Type 2) : Type 2 :=
   EStateM (ULift Program.Error) RmState a
-
-/-- The evaluation monad -/
-def modify' (f : RmState → RmState) : RunM PUnit := modify (fun s => f s)
-
-def get' : RunM RmState := get
-
-def set' (s : RmState) : RunM PUnit := set s
 
 def throw' {α : Type _} (e : Program.Error) : RunM α :=
   throw (ULift.up e)
@@ -52,9 +46,7 @@ def checkDelta (consumed created : List Resource) : RunM PUnit := do
     let numCreated := getQuantityOfKind createdByKind kind
     if numConsumed == numCreated
     then pure .unit
-    -- TODO uncomment
-    -- else throw' (.balanceCheck s!"numConsumed: {numConsumed}/{consumed.length}, numCreated: {numCreated}/{created.length}")
-    else pure .unit
+    else throw' (.balanceCheck s!"numConsumed: {numConsumed}/{consumed.length}, numCreated: {numCreated}/{created.length}")
 
 def picks {A : Type u} (l : List A) : List (A × List A) :=
   List.finRange l.length |>.map (fun i => ⟨l.get i, l.eraseIdx i⟩)
@@ -65,8 +57,8 @@ def fetchLogic (ref : LogicRef) : RunM (LogicFunction) := do
   | none => throw' (.missingLogic ref)
   | some s => pure s
 
-def storeLogic (ref : LogicRef) (f : LogicFunction) := do
-  modify' (fun s => {s with logics := s.logics.insert ref f})
+def storeLogic (ref : LogicRef) (f : LogicFunction) : RunM PUnit := do
+  modify (fun s => {s with logics := s.logics.insert ref f})
 
 def storeCreated (created : List Resource) : RunM PUnit := do
   let created := created.filter (·.ephemeral.not)
@@ -74,8 +66,8 @@ def storeCreated (created : List Resource) : RunM PUnit := do
     dbgTrace s!"created" (fun _ =>
     let try val : AVM.Object.Resource.SomeValue := tryCast r.value
     dbgTrace s!"hi: {val.uid}" (fun _ =>
-    modify' (fun s => {s with objects := s.objects.insert val.uid r
-                              commited := s.commited.insert r.commitment})))
+    modify (fun s => {s with objects := s.objects.insert val.uid r
+                             commited := s.commited.insert r.commitment})))
 
 def runAction (a : Action) : RunM PUnit := do
   let units : List ComplianceUnit := a.complianceUnits
@@ -109,7 +101,7 @@ def runAction (a : Action) : RunM PUnit := do
   -- TODO nullify consumed
 
 def logmsg (msg : String) : RunM PUnit :=
-  modify' (fun s => {s with logs := s.logs.cons msg})
+  modify (fun s => {s with logs := s.logs.cons msg})
 
 def runTransaction (t : Transaction) : RunM PUnit := do
   let actions : List Action := t.actions
@@ -122,7 +114,7 @@ def interpret : Program → RunM PUnit
   | .skip => pure .unit
   | .raise err => throw' err
   | .log msg next => do
-    modify' (fun s => {s with logs := s.logs.cons msg})
+    modify (fun s => {s with logs := s.logs.cons msg})
     interpret next
   | .tryCatch b handle next =>
       try do
@@ -138,9 +130,9 @@ def interpret : Program → RunM PUnit
     runTransaction t
     interpret next
   | .withRandomGen next => do
-    let s ← get'
+    let s ← get
     let ⟨gen1, gen2⟩ := stdSplit s.gen
-    set' {s with gen := gen1}
+    set {s with gen := gen1}
     next gen2 |>.interpret
 
 def eval {lab : AVM.Scope.Label} (scope : AVM.Scope lab) (p : Program) : EStateM.Result (ULift Program.Error) RmState PUnit :=

--- a/Anoma/Simulator.lean
+++ b/Anoma/Simulator.lean
@@ -103,7 +103,7 @@ def runAction (a : SplitAction) : RunM PUnit := do
         let logic <- fetchLogic self.logicRef
         if logic args
         then pure .unit
-        else throw' (.logicFailed)
+        else throw' (.logicFailed self.logicRef)
   for (r, consumed') in consumedPicks do
     checkLogic r .Consumed consumed' created
   for (r, created') in createdPicks do
@@ -161,6 +161,5 @@ def run {lab : AVM.Scope.Label} (scope : AVM.Scope lab) (p : Program) : IO Unit 
     IO.println "success"
   | .error err s => do
     printLogs s.logs
-    IO.println "error"
     IO.println (repr err.down)
     IO.Process.exit 1

--- a/Anoma/Transaction.lean
+++ b/Anoma/Transaction.lean
@@ -4,8 +4,8 @@ import Anoma.Delta
 
 namespace Anoma
 
-structure Transaction where
-  actions : List Action
+structure Transaction.{u, v} : Type (max u v + 1) where
+  actions : List Action.{u, v}
   deltaProof : DeltaProof
 
 def Transaction.generateDeltaProof (witness : DeltaWitness) (actions : List Action) : DeltaProof :=

--- a/Anoma/Transaction.lean
+++ b/Anoma/Transaction.lean
@@ -4,8 +4,8 @@ import Anoma.Delta
 
 namespace Anoma
 
-structure Transaction.{u, v} : Type (max u v + 1) where
-  actions : List Action.{u, v}
+structure Transaction : Type 2 where
+  actions : List Action
   deltaProof : DeltaProof
 
 def Transaction.generateDeltaProof (witness : DeltaWitness) (actions : List Action) : DeltaProof :=

--- a/Applib/Surface/Program.lean
+++ b/Applib/Surface/Program.lean
@@ -69,6 +69,11 @@ inductive Program (lab : Scope.Label) : (α : Type u) → Type (u + 1) where
     {α : Type u}
     (val : α)
     : Program lab α
+  | log
+    {α : Type u}
+    (msg : String)
+    (next : Program lab α)
+    : Program lab α
 
 def Program.toAVM {lab : Scope.Label} {α} (prog : Program lab α) : AVM.Program lab α :=
   match prog with
@@ -88,6 +93,8 @@ def Program.toAVM {lab : Scope.Label} {α} (prog : Program lab α) : AVM.Program
     .invoke (toAVM p) (fun x => toAVM (next x))
   | .return val =>
     .return val
+  | .log msg next =>
+    .log msg (toAVM next)
 
 def Program.map {lab : Scope.Label} {A B : Type u} (f : A → B) (prog : Program.{u} lab A) : Program.{u} lab B :=
   match prog with
@@ -107,6 +114,8 @@ def Program.map {lab : Scope.Label} {A B : Type u} (f : A → B) (prog : Program
     .invoke p (fun x => map f (next x))
   | .return val =>
     .return (f val)
+  | .log msg next =>
+    .log msg (map f next)
 
 def Program.create'
   {α}

--- a/Applib/Surface/Program/Syntax.lean
+++ b/Applib/Surface/Program/Syntax.lean
@@ -76,6 +76,8 @@ syntax colGe "invoke " term : program
 syntax colGe withPosition("invoke " term) optSemicolon(program) : program
 syntax colGe withPosition(ident " := " " invoke " term) optSemicolon(program) : program
 syntax colGe withPosition(ident " := " " fetch " term) optSemicolon(program) : program
+syntax colGe "log " term : program
+syntax colGe withPosition("log " term) optSemicolon(program) : program
 syntax colGe "return " term : program
 syntax colGe "!" term : program
 syntax "⟪" withPosition(program) "⟫" : term
@@ -139,6 +141,10 @@ macro_rules
     `(Program.upgrade' (inScope := by scoper) $e $e' Program.return)
   | `(⟪upgrade $e:term to $e':term ; $p:program⟫) =>
     `(Program.upgrade' (inScope := by scoper) $e $e' (⟪$p⟫))
+  | `(⟪log $e:term⟫) =>
+    `(Program.log $e Program.return)
+  | `(⟪log $e:term ; $p:program⟫) =>
+    `(Program.log $e (⟪$p⟫))
   | `(⟪invoke $e:term⟫) =>
     `(Program.invoke $e Program.return)
   | `(⟪invoke $e:term ; $p:program⟫) =>

--- a/Applib/Surface/Reference.lean
+++ b/Applib/Surface/Reference.lean
@@ -7,12 +7,11 @@ open AVM
 
 structure Reference (C : Type) where
   objId : ObjectId
-  deriving Inhabited, Repr, BEq
+  deriving Inhabited, Repr, BEq, Hashable
 
 instance Reference.hasTypeRep {C : Type} [TypeRep C] : TypeRep (Reference C) where
   rep := Rep.composite "Reference" [TypeRep.rep C]
 
--- TODO better name?
 structure ObjectReference {lab : Ecosystem.Label} (classId : lab.ClassId) : Type 1 where
   {type : Type}
   ref : Reference type

--- a/Apps/Kudos.lean
+++ b/Apps/Kudos.lean
@@ -1,7 +1,5 @@
 import AVM
 import Applib
-import Mathlib.Data.Fintype.Basic
-import Mathlib.Tactic.DeriveFintype
 
 open Applib
 
@@ -18,17 +16,17 @@ open Applib
 structure KudosData where
   originator : PublicKey
   owner : PublicKey
-  deriving DecidableEq, Inhabited
+  deriving DecidableEq, Inhabited, Hashable
 
 structure Kudos extends KudosData where
   quantity : Nat
-  deriving DecidableEq, Inhabited
+  deriving DecidableEq, Inhabited, Hashable
 
 namespace Kudos
 
 inductive Methods where
   | Transfer : Methods
-  deriving DecidableEq, Fintype, Repr
+  deriving DecidableEq, FinEnum, Repr
 
 namespace Methods
 
@@ -43,7 +41,7 @@ end Methods
 
 inductive Constructors where
   | Mint : Constructors
-  deriving DecidableEq, Fintype, Repr
+  deriving DecidableEq, FinEnum, Repr
 
 namespace Constructors
 
@@ -59,7 +57,7 @@ end Constructors
 
 inductive Destructors where
   | Burn : Destructors
-  deriving DecidableEq, Fintype, Repr
+  deriving DecidableEq, FinEnum, Repr
 
 namespace Destructors
 
@@ -87,14 +85,14 @@ instance hasTypeRep : TypeRep Kudos where
 structure MintArgs where
   originator : PublicKey
   quantity : Nat
-  deriving BEq
+  deriving BEq, Hashable
 
 instance MintArgs.hasTypeRep : TypeRep MintArgs where
   rep := Rep.atomic "MintArgs"
 
 structure TransferArgs where
   newOwner : PublicKey
-  deriving DecidableEq
+  deriving DecidableEq, Hashable
 
 instance TransferArgs.hasTypeRep : TypeRep TransferArgs where
   rep := Rep.atomic "TransferArgs"
@@ -135,7 +133,7 @@ inductive ArgNames where
 export ArgNames (Kudos1 Kudos2)
 
 structure Args where
-  deriving BEq
+  deriving BEq, Hashable
 
 instance Args.hasTypeRep : TypeRep Args where
   rep := Rep.atomic "Kudos.Merge.Args"
@@ -152,7 +150,7 @@ export ArgNames (Kudos)
 
 structure Args where
   quantities : List Nat
-  deriving BEq
+  deriving BEq, Hashable
 
 instance Args.hasTypeRep : TypeRep Args where
   rep := Rep.atomic "Kudos.Split.Args"

--- a/Apps/KudosBank.lean
+++ b/Apps/KudosBank.lean
@@ -1,7 +1,5 @@
 import AVM
 import Applib
-import Mathlib.Data.Fintype.Basic
-import Mathlib.Tactic.DeriveFintype
 
 open Applib
 
@@ -16,7 +14,7 @@ structure Denomination where
 
 structure Account where
   assets : Std.HashMap Denomination Nat
-  deriving BEq, Inhabited
+  deriving BEq, Inhabited, Hashable
 
 namespace Account
 
@@ -42,7 +40,7 @@ end Account
 
 structure Balances where
   accounts : Std.HashMap PublicKey Account
-  deriving BEq, Inhabited
+  deriving Inhabited, BEq, Hashable
 
 namespace Balances
 
@@ -67,7 +65,7 @@ structure Check where
   denomination : Denomination
   owner : PublicKey
   quantity : Nat
-  deriving BEq, Inhabited
+  deriving BEq, Inhabited, Hashable
 
 namespace Check
 
@@ -78,11 +76,11 @@ instance hasTypeRep : TypeRep Check where
 
 inductive Methods where
   | Transfer
-  deriving Repr, BEq, Fintype, DecidableEq
+  deriving Repr, BEq, DecidableEq, FinEnum
 
 structure TransferArgs where
   newOwner : PublicKey
-  deriving DecidableEq
+  deriving DecidableEq, Hashable
 
 instance TransferArgs.hasTypeRep : TypeRep TransferArgs where
   rep := Rep.atomic "Check.TransferArgs"
@@ -109,7 +107,7 @@ structure Auction where
   biddingDenomination : Denomination
   highestBid : Nat
   highestBidder : PublicKey
-  deriving BEq, Inhabited
+  deriving BEq, Inhabited, Hashable
 
 namespace Auction
 
@@ -136,7 +134,7 @@ end Auction
 structure KudosBank where
   owner : PublicKey
   balances : Balances
-  deriving Inhabited, BEq
+  deriving Inhabited, BEq, Hashable
 
 namespace KudosBank
 
@@ -156,7 +154,7 @@ inductive Methods where
   | Transfer : Methods
   | Mint : Methods
   | Burn : Methods
-  deriving DecidableEq, Fintype, Repr
+  deriving DecidableEq, FinEnum, Repr
 
 namespace Methods
 
@@ -183,11 +181,11 @@ end Methods
 
 inductive Constructors where
   | Open : Constructors
-  deriving DecidableEq, Fintype, Repr
+  deriving DecidableEq, FinEnum, Repr
 
 inductive Destructors where
   | Close : Destructors
-  deriving DecidableEq, Fintype, Repr
+  deriving DecidableEq, FinEnum, Repr
 
 namespace Destructors
 
@@ -211,7 +209,7 @@ instance hasTypeRep : TypeRep KudosBank where
 structure MintArgs where
   denom : Denomination
   quantity : Nat
-  deriving BEq
+  deriving BEq, Hashable
 
 instance MintArgs.hasTypeRep : TypeRep MintArgs where
   rep := Rep.atomic "MintArgs"
@@ -228,7 +226,7 @@ structure TransferArgs where
   newOwner : PublicKey
   denom : Denomination
   quantity : Nat
-  deriving DecidableEq
+  deriving DecidableEq, Hashable
 
 instance TransferArgs.hasTypeRep : TypeRep TransferArgs where
   rep := Rep.atomic "TransferArgs"
@@ -237,7 +235,7 @@ structure BurnArgs where
   denom : Denomination
   owner : PublicKey
   quantity : Nat
-  deriving DecidableEq
+  deriving DecidableEq, Hashable
 
 instance BurnArgs.hasTypeRep : TypeRep BurnArgs where
   rep := Rep.atomic "BurnArgs"
@@ -276,7 +274,7 @@ structure Args where
   denomination : Denomination
   owner : PublicKey
   quantity : Nat
-  deriving BEq
+  deriving BEq, Hashable
 
 inductive SignatureId : Type where
   | owner
@@ -294,7 +292,7 @@ end IssueCheck
 namespace DepositCheck
 
 structure Args where
-  deriving BEq
+  deriving BEq, Hashable
 
 inductive SignatureId : Type where
   | owner
@@ -314,7 +312,7 @@ namespace NewAuction
 
 structure Args where
   biddingDenomination : Denomination
-  deriving BEq
+  deriving BEq, Hashable
 
 inductive SignatureId : Type where
   | owner
@@ -332,7 +330,7 @@ end NewAuction
 namespace Bid
 
 structure Args where
-  deriving BEq
+  deriving BEq, Hashable
 
 instance Args.hasTypeRep : TypeRep Args where
   rep := Rep.atomic "Bid.Args"
@@ -351,7 +349,7 @@ end Bid
 namespace EndAuction
 
 structure Args where
-  deriving BEq
+  deriving BEq, Hashable
 
 inductive SignatureId : Type where
   | owner

--- a/Apps/OwnedCounter.lean
+++ b/Apps/OwnedCounter.lean
@@ -1,14 +1,12 @@
 import AVM
 import Applib
-import Mathlib.Data.Fintype.Basic
-import Mathlib.Tactic.DeriveFintype
 
 open Applib
 
 structure OwnedCounter where
   count : Nat
   owner : PublicKey
-  deriving Inhabited, Repr, BEq
+  deriving Inhabited, Repr, BEq, Hashable
 
 namespace OwnedCounter
 
@@ -18,7 +16,7 @@ instance hasTypeRep : TypeRep OwnedCounter where
 inductive Methods where
   | Incr : Methods
   | Transfer : Methods
-  deriving DecidableEq, Fintype, Repr
+  deriving DecidableEq, FinEnum, Repr
 
 namespace Methods
 
@@ -38,11 +36,11 @@ end Methods
 
 inductive Constructors where
   | Zero : Constructors
-  deriving DecidableEq, Fintype, Repr
+  deriving DecidableEq, FinEnum, Repr
 
 inductive Destructors where
   | Ten : Destructors
-  deriving DecidableEq, Fintype, Repr
+  deriving DecidableEq, FinEnum, Repr
 
 namespace Destructors
 

--- a/Apps/TwoCounter.lean
+++ b/Apps/TwoCounter.lean
@@ -1,7 +1,5 @@
 import AVM
 import Applib
-import Mathlib.Data.Fintype.Basic
-import Mathlib.Tactic.DeriveFintype
 
 open Applib
 open AVM
@@ -15,7 +13,7 @@ inductive Classes where
 
 structure Counter where
   count : Nat
-  deriving Inhabited, Repr, BEq
+  deriving Inhabited, Repr, BEq, Hashable
 
 instance Counter.HasTypeRep : TypeRep Counter where
   rep := Rep.atomic "TwoCounter.Counter"
@@ -24,11 +22,11 @@ namespace Counter
 
 inductive Methods where
   | Incr : Methods
-  deriving DecidableEq, Fintype, Repr
+  deriving DecidableEq, FinEnum, Repr
 
 inductive Constructors where
   | Zero : Constructors
-  deriving DecidableEq, Fintype, Repr
+  deriving DecidableEq, FinEnum, Repr
 
 def lab : Class.Label where
   name := "UniversalCounter"
@@ -58,11 +56,11 @@ namespace TwoCounter
 
 inductive Constructors where
   | Zero : Constructors
-  deriving DecidableEq, Fintype, Repr
+  deriving DecidableEq, FinEnum, Repr
 
 inductive Methods where
   | IncrementBoth : Methods
-  deriving DecidableEq, Fintype, Repr
+  deriving DecidableEq, FinEnum, Repr
 
 def lab : Class.Label where
   name := "TwoCounter"

--- a/Apps/UniversalCounter.lean
+++ b/Apps/UniversalCounter.lean
@@ -1,7 +1,6 @@
 import AVM
 import Applib
-import Mathlib.Data.Fintype.Basic
-import Mathlib.Tactic.DeriveFintype
+import Anoma
 import Applib.Surface.Program.Syntax
 
 open Applib
@@ -14,11 +13,11 @@ namespace Counter
 
 inductive Methods where
   | Incr : Methods
-  deriving DecidableEq, Fintype, Repr
+  deriving DecidableEq, FinEnum, Repr
 
 inductive Constructors where
   | Zero : Constructors
-  deriving DecidableEq, Fintype, Repr
+  deriving DecidableEq, FinEnum, Repr
 
 inductive MultiMethods where
   | Merge : MultiMethods
@@ -133,7 +132,15 @@ def counterEcosystem : Ecosystem label where
   multiMethods := fun
     | .Merge => mergeMethod
 
-example (rx ry : Reference Counter) : Applib.Program label.toScope Unit := ⟪
+def example1 : Applib.Program label.toScope Unit := ⟪
+  -- log s!"create"
+  c1 := create Counter Counter.Constructors.Zero ()
+  -- c1' := fetch c1
+  -- log s!"hi {c1'.count}"
+  return .unit
+⟫
+
+def example2 (rx ry : Reference Counter) : Applib.Program label.toScope Unit := ⟪
   let selves :
       @Ecosystem.Label.MultiMethodId.SelvesReferences label
       Counter.MultiMethods.Merge := fun
@@ -145,3 +152,13 @@ example (rx ry : Reference Counter) : Applib.Program label.toScope Unit := ⟪
                          ref := ry }
   multiCall[ .unit ] Counter.MultiMethods.Merge selves .unit
 ⟫
+
+def scope : AVM.Scope label.toScope := counterEcosystem.toScope
+
+end Counter
+
+def runProgram {α} (prog : Applib.Program Counter.label.toScope α) : IO Unit :=
+  let p : Anoma.Program := prog.map (fun _ => Unit.unit) |>.toAVM.compile Counter.scope
+  p.run ∅
+
+def main : IO Unit := runProgram Counter.example1

--- a/Apps/UniversalCounter.lean
+++ b/Apps/UniversalCounter.lean
@@ -1,6 +1,7 @@
 import AVM
 import Applib
 import Anoma
+import Anoma.Eval
 import Applib.Surface.Program.Syntax
 
 open Applib
@@ -159,6 +160,6 @@ end Counter
 
 def runProgram {α} (prog : Applib.Program Counter.label.toScope α) : IO Unit :=
   let p : Anoma.Program := prog.map (fun _ => Unit.unit) |>.toAVM.compile Counter.scope
-  p.run ∅
+  p.run Counter.scope
 
 def main : IO Unit := runProgram Counter.example1

--- a/Apps/UniversalCounter.lean
+++ b/Apps/UniversalCounter.lean
@@ -1,7 +1,7 @@
 import AVM
 import Applib
 import Anoma
-import Anoma.Eval
+import Anoma.Simulator
 import Applib.Surface.Program.Syntax
 
 open Applib

--- a/Apps/UniversalCounter.lean
+++ b/Apps/UniversalCounter.lean
@@ -134,10 +134,7 @@ def counterEcosystem : Ecosystem label where
     | .Merge => mergeMethod
 
 def example1 : Applib.Program label.toScope Unit := ⟪
-  -- log s!"create"
   c1 := create Counter Counter.Constructors.Zero ()
-  -- c1' := fetch c1
-  -- log s!"hi {c1'.count}"
   return .unit
 ⟫
 

--- a/Prelude.lean
+++ b/Prelude.lean
@@ -5,10 +5,12 @@ import Prelude.Function
 import Prelude.HBeq
 import Prelude.HList
 import Prelude.HashMap
+import Prelude.Hashable
+import Prelude.Hashable.Mix
 import Prelude.LetBang
 import Prelude.LetTry
 import Prelude.List
 import Prelude.SomeType
 import Prelude.TypeRep
-import Prelude.Vector
 import Prelude.ULift
+import Prelude.Vector

--- a/Prelude/Hashable.lean
+++ b/Prelude/Hashable.lean
@@ -1,0 +1,7 @@
+import Std.Data.HashMap.Basic
+
+instance {α : Type u} [Hashable α] : Hashable (ULift.{v} α) where
+  hash d := hash d.down
+
+instance {α β : Type u} [BEq α] [Hashable α] [Hashable β] : Hashable (Std.HashMap α β) where
+  hash m := m.toList |>.map hash |>.mergeSort |> hash

--- a/Prelude/Hashable/Mix.lean
+++ b/Prelude/Hashable/Mix.lean
@@ -1,0 +1,19 @@
+namespace Hashable
+
+structure MixState : Type where
+  hash : UInt64
+
+abbrev MixState.empty : MixState where
+  hash := Hashable.hash Unit.unit
+
+/-- A monad for conveniently mixing hashes with do-notation. -/
+abbrev Mix : Type := StateM MixState Unit
+
+def Mix.mix {α : Type u} [Hashable α] (a : α) : Mix :=
+  modify (fun s => { s with hash := mixHash s.hash (hash a) })
+
+def Mix.run (m : Mix) : UInt64 := StateT.run m MixState.empty |>.snd.hash
+
+end Hashable
+
+export Hashable.Mix (mix)

--- a/Prelude/SomeType.lean
+++ b/Prelude/SomeType.lean
@@ -5,6 +5,7 @@ structure SomeType : Type (u + 1) where
   type : Type u
   [typeTypeRep : TypeRep type]
   [typeBEq : BEq type]
+  [typeHashable : Hashable type]
 
 instance SomeType.hasTypeRep : TypeRep SomeType where
   rep := Rep.atomic "SomeType"

--- a/Prelude/TypeRep.lean
+++ b/Prelude/TypeRep.lean
@@ -8,7 +8,7 @@ inductive Rep where
   | atomic (encoding : String)
   /-- `Rep.composite` is used for parameterised data types -/
   | composite (name : String) (params : List Rep)
-  deriving Inhabited, Repr
+  deriving Inhabited, Repr, Hashable
 
 partial def Rep.decEq (a b : Rep) : Decidable (Eq a b) :=
   match a with

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -31,3 +31,13 @@ name = "Goose"
 
 [[lean_lib]]
 name = "Tests"
+
+[[lean_exe]]
+name = "Runner"
+srcDir = "Apps"
+root = "UniversalCounter"
+
+[[lean_exe]]
+name = "hello"
+srcDir = "hello"
+root = "Hello"

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -36,8 +36,3 @@ name = "Tests"
 name = "Runner"
 srcDir = "Apps"
 root = "UniversalCounter"
-
-[[lean_exe]]
-name = "hello"
-srcDir = "hello"
-root = "Hello"


### PR DESCRIPTION
Major changes in this pr:
1. Implements a partial implementation of a resource machine simulator in `Anoma.Simulator.lean`. A simple example can be run with `lake exe Runner`. Currently it fails the balance check and the resource logic check. I believe it is better that we merge this now and try to fix these issues on a separate pr.
2. I've added a new `log` statement to the surface language.
3. `SomeType` also requires a `Hashable` instance for `type`. I've added a `Hashable` instance for many types.

Minor changes:
1. Removes universe polymorphism from `Resource` and all the types that depend on it. I think this is worth it because it simplifies the codebase and we only used `Resource` at universe levels {1, 1} anyway.
4. Simplifies `Program.withRandomGen`. The caller is no longer responsible for returning the updated `StdGen`.
5. Adds the `Mix` monad for conveniently generating `Hashable` instances with do-notation.
6. `ComplianceUnit` now includes the `ComplianceWitness`. This is needed for the simulator.
7. I've removed the program statements that are not required for the current state of goose. E.g. `decrypt`, `generateIdentity`, `requestCommitment`, etc.
