### PR TITLE
fix: check consistency of sub-objects

### DIFF
--- a/AVM/Class/Translation/Logics.lean
+++ b/AVM/Class/Translation/Logics.lean
@@ -203,10 +203,13 @@ private def Upgrade.Message.logicFun
     && selfRes.isPersistent
     && upgradedRes.isPersistent
 
-/-- The class logic checks if the message consumed in the action is associated
-    with the same ecosystem, the `self` object is among the message recipients
-    and the number of recipients is equal to the number of consumed object
-    resources. The class logic also checks the class invariant for `self`. -/
+/-- The class logic checks if one the following holds.
+    1. The message consumed in the action is associated with the same ecosystem,
+       the `self` object is among the message recipients, and the number of
+       recipients is at least the number of consumed object resources which are
+       not modified. The class logic also checks the class invariant for `self`.
+    2. The `self` object is not modified.
+  -/
 private def logicFun
   {lab : Ecosystem.Label}
   {classId : lab.ClassId}
@@ -218,20 +221,23 @@ private def logicFun
   match args.status with
   | Created => true
   | Consumed =>
-    let consumedObjectResources : List Anoma.Resource := Logic.selectObjectResources args.consumed
-    let! [consumedMessageResource] := Logic.selectMessageResources args.consumed
-    -- Note: the success of the `try` below ensures that the message is "legal"
-    -- for the consumed objects - it is from the same ecosystem
-    let try msg : Message lab := Message.fromResource consumedMessageResource
-    self.uid ∈ msg.recipients
-    && msg.recipients.length == consumedObjectResources.length
-    -- Note that the message logics already check if the consumed object
-    -- resources have the right form, i.e., correspond to the self / selves. We
-    -- only need to check that the number of recipients is equal to the number
-    -- of consumed object resources, i.e., there are no extra recipients. The
-    -- class logic will be run for each consumed object, with `self` set to that
-    -- object, so it will be checked if every consumed object is among the
-    -- recipients.
+    if args.self.isPersistent && Logic.isObjectPreserved self.toObjectValue args.created then
+      true
+    else
+      let consumedObjectResources : List Anoma.Resource := Logic.selectObjectResources args.consumed
+      let! [consumedMessageResource] := Logic.selectMessageResources args.consumed
+      -- Note: the success of the `try` below ensures that the message is "legal"
+      -- for the consumed objects - it is from the same ecosystem
+      let try msg : Message lab := Message.fromResource consumedMessageResource
+      self.uid ∈ msg.recipients
+      && msg.recipients.length == consumedObjectResources.length
+      -- Note that the message logics already check if the consumed object
+      -- resources have the right form, i.e., correspond to the self / selves. We
+      -- only need to check that the number of recipients is equal to the number
+      -- of consumed object resources, i.e., there are no extra recipients. The
+      -- class logic will be run for each consumed object, with `self` set to that
+      -- object, so it will be checked if every consumed object is among the
+      -- recipients.
 
 /-- The class logic that is the Resource Logic of each resource corresponding to
   an object of this class. -/

--- a/AVM/Class/Translation/Tasks.lean
+++ b/AVM/Class/Translation/Tasks.lean
@@ -86,14 +86,14 @@ private partial def Body.tasks'
     Tasks.fetch selfId fun self => Tasks.rand fun r =>
       let task := destr.task' adjust eco r (adjust self) args signatures
       Tasks.task task.task fun vals =>
-        Body.tasks' cnt (task.adjust vals) scope next cont
+        Body.tasks' (cnt + 1) (task.adjust vals) scope next cont
   | .method ecoId classId methodId selfId args signatures next =>
     let eco := scope.ecosystems ecoId
     let method := eco.classes classId |>.methods methodId
     Tasks.fetch selfId fun self => Tasks.rand fun r =>
       let task := method.task' adjust eco r (adjust self) args signatures
       Tasks.task task.task fun vals =>
-        Body.tasks' cnt (task.adjust vals) scope next cont
+        Body.tasks' (cnt + 1) (task.adjust vals) scope next cont
   | .multiMethod ecoId multiId selvesIds args signatures next =>
     let eco := scope.ecosystems ecoId
     Tasks.fetchSelves selvesIds fun selves =>
@@ -106,10 +106,10 @@ private partial def Body.tasks'
     Tasks.fetch selfId fun self => Tasks.rand fun r =>
       let task := Class.Upgrade.task' (classId := classId) adjust eco r (adjust self) objData
       Tasks.task task.task fun vals =>
-        Body.tasks' cnt (task.adjust vals) scope next cont
+        Body.tasks' (cnt + 1) (task.adjust vals) scope next cont
   | .fetch objId next =>
     Tasks.fetch objId fun obj =>
-      Body.tasks' cnt adjust scope (next (adjust obj)) cont
+      Body.tasks' (cnt + 1) adjust scope (next (adjust obj)) cont
       |>.map (fun res => ⟨res.value, res.adjust, ⟨adjust obj, res.bodyParameterValues⟩, res.fetchedObjectsRands⟩)
   | .return val =>
     Tasks.rands cnt fun rands =>

--- a/AVM/Program.lean
+++ b/AVM/Program.lean
@@ -140,3 +140,27 @@ def value {lab : Scope.Label} {α : Type u} (prog : Program lab α) (vals : prog
     next obj |>.value vals'
   | .return val =>
     val
+
+/-- All objects fetched in the program.  The `vals` provided need to be adjusted
+  (see `Program.Parameters.Product`). -/
+def objects {lab : Scope.Label} {α : Type u} (prog : Program lab α) (vals : prog.params.Product) : List SomeObject :=
+  match prog with
+  | .constructor _ _ _ _ _ next =>
+    let ⟨newId, vals'⟩ := vals
+    objects (next newId) vals'
+  | .destructor _ _ _ _ _ _ next =>
+    next.objects vals
+  | .method _ _ _ _ _ _ next =>
+    next.objects vals
+  | .multiMethod _ _ _ _ _ next =>
+    next.objects vals
+  | .upgrade _ _ _ _ next =>
+    next.objects vals
+  | .fetch _ next =>
+    let ⟨obj, vals'⟩ := vals
+    obj.toSomeObject :: objects (next obj) vals'
+  | .return _ => []
+
+end Program
+
+end AVM


### PR DESCRIPTION
- Closes #103 
- Includes the resources corresponding to fetched objects in the action for the method (as consumed and created with no data modification). This ensures that the fetched objects data actually corresponds to the objects in the system.
