### PR TITLE
Debug

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -15,3 +15,6 @@ jobs:
       - uses: leanprover/lean-action@v1
         with:
           build-args: "--wfail"
+      - name: Run UniversalCounter example
+          run: |
+            lake exe counter

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -16,5 +16,5 @@ jobs:
         with:
           build-args: "--wfail"
       - name: Run UniversalCounter example
-          run: |
-            lake exe counter
+        run: |
+          lake exe counter

--- a/AVM/Action/DummyResource.lean
+++ b/AVM/Action/DummyResource.lean
@@ -17,8 +17,6 @@ def isDummyResource (res : Anoma.Resource) : Bool :=
   res.ephemeral &&
   res.quantity == 0
 
-#check Anoma.Logic.Error.rawError
-
 /-- The resource logic of any dummy resource. -/
 private def dummyResourceLogic : Anoma.Logic :=
   { reference := dummyResourceLogicRef,

--- a/AVM/Action/DummyResource.lean
+++ b/AVM/Action/DummyResource.lean
@@ -22,7 +22,8 @@ private def dummyResourceLogic : Anoma.Logic :=
     function :=
       fun (args : Anoma.Logic.Args) =>
         let res : Anoma.Resource := args.self
-        isDummyResource res }
+        check isDummyResource res
+        pure .unit }
 
 /-- A dummy resource used in generated actions. -/
 def dummyResource (nonce : Anoma.Nonce) : Anoma.Resource :=

--- a/AVM/Action/DummyResource.lean
+++ b/AVM/Action/DummyResource.lean
@@ -1,5 +1,6 @@
 import Prelude
 import Anoma
+import Anoma.Logic
 
 namespace AVM.Action
 
@@ -15,6 +16,8 @@ def isDummyResource (res : Anoma.Resource) : Bool :=
   res.logicRef == dummyResourceLogicRef &&
   res.ephemeral &&
   res.quantity == 0
+
+#check Anoma.Logic.Error.rawError
 
 /-- The resource logic of any dummy resource. -/
 private def dummyResourceLogic : Anoma.Logic :=

--- a/AVM/Action/DummyResource.lean
+++ b/AVM/Action/DummyResource.lean
@@ -18,7 +18,7 @@ def isDummyResource (res : Anoma.Resource) : Bool :=
   res.quantity == 0
 
 /-- The resource logic of any dummy resource. -/
-private def dummyResourceLogic : Anoma.Logic :=
+def dummyResourceLogic : Anoma.Logic :=
   { reference := dummyResourceLogicRef,
     function :=
       fun (args : Anoma.Logic.Args) =>

--- a/AVM/Class/Label.lean
+++ b/AVM/Class/Label.lean
@@ -52,6 +52,9 @@ structure Label : Type 1 where
   [methodsBEq : BEq MethodId]
   [methodsLawfulBEq : LawfulBEq MethodId]
 
+instance Label.instRepr : Repr Label where
+  reprPrec l _ := l.name
+
 instance Label.instHashable : Hashable Label where
   hash l := hash l.name
 

--- a/AVM/Class/Label.lean
+++ b/AVM/Class/Label.lean
@@ -88,13 +88,6 @@ instance (lab : Class.Label) : Repr (Label.MemberId lab) where
   | .methodId methodId => s!"destructor {repr methodId}"
   | .upgradeId  => "upgradeId"
 
-
-abbrev Label.MemberId.SignatureId {lab : Class.Label} : Label.MemberId lab → Type
-  | .methodId m => lab.MethodSignatureId m
-  | .destructorId m => lab.DestructorSignatureId m
-  | .constructorId m => lab.ConstructorSignatureId m
-  | .upgradeId => Empty
-
 instance Label.MemberId.instHashable {lab : Class.Label} : Hashable (Class.Label.MemberId lab) where
   hash l := Hashable.Mix.run do
     mix lab

--- a/AVM/Class/Label.lean
+++ b/AVM/Class/Label.lean
@@ -77,6 +77,24 @@ inductive Label.MemberId (lab : Class.Label) : Type where
   | methodId (methodId : lab.MethodId) : MemberId lab
   | upgradeId : MemberId lab
 
+instance (lab : Class.Label) : Repr (Label.MemberId lab) where
+  reprPrec m _ :=
+  have := lab.constructorsRepr
+  have := lab.destructorsRepr
+  have := lab.methodsRepr
+  match m with
+  | .constructorId constrId => s!"constructor {repr constrId}"
+  | .destructorId destructorId => s!"destructor {repr destructorId}"
+  | .methodId methodId => s!"destructor {repr methodId}"
+  | .upgradeId  => "upgradeId"
+
+
+abbrev Label.MemberId.SignatureId {lab : Class.Label} : Label.MemberId lab → Type
+  | .methodId m => lab.MethodSignatureId m
+  | .destructorId m => lab.DestructorSignatureId m
+  | .constructorId m => lab.ConstructorSignatureId m
+  | .upgradeId => Empty
+
 instance Label.MemberId.instHashable {lab : Class.Label} : Hashable (Class.Label.MemberId lab) where
   hash l := Hashable.Mix.run do
     mix lab

--- a/AVM/Class/Translation/Logics.lean
+++ b/AVM/Class/Translation/Logics.lean
@@ -153,8 +153,8 @@ private def Constructor.Message.logicFun
   let newObjData := body.value vals
   let consumedResObjs := Logic.selectObjectResources (args.consumed ++ if args.isConsumed then [args.self] else [])
   let createdResObjs := Logic.selectObjectResources (args.created ++ if args.isConsumed then [] else [args.self])
-  dolet! (newObjRes :: _) := createdResObjs
-  dolet! (consumedObjRes :: consumedFetchedResObjs) := consumedResObjs
+  let! (newObjRes :: _) := createdResObjs
+  let! (consumedObjRes :: consumedFetchedResObjs) := consumedResObjs
     failwith throw (.custom here#
     s!"consumedResObjs.length = {consumedResObjs.length}
     args.consumed:\n{repr args.consumed}
@@ -189,8 +189,8 @@ private def Destructor.Message.logicFun
   let argsData := cast (by simp! [eq_of_beq h]) msg.data.args
   let consumedResObjs := Logic.selectObjectResources args.consumed
   let createdResObjs := Logic.selectObjectResources args.created
-  dolet! (selfRes :: _) := consumedResObjs
-  dolet! (createdResObj :: createdFetchedResObjs) := createdResObjs
+  let! (selfRes :: _) := consumedResObjs
+  let! (createdResObj :: createdFetchedResObjs) := createdResObjs
   let catch selfObj : Object classId := Object.fromResource selfRes
     failwith fun (err : String) => throw (.custom here# err)
   let body := destructor.body selfObj argsData
@@ -221,7 +221,7 @@ private def Method.Message.logicFun
   let argsData : methodId.Args.type := cast (by simp! [eq_of_beq h]) msg.data.args
   let consumedResObjs := Logic.selectObjectResources args.consumed
   let createdResObjs := Logic.selectObjectResources args.created
-  dolet! (selfRes :: _) := consumedResObjs
+  let! (selfRes :: _) := consumedResObjs
   let catch selfObj : Object classId := Object.fromResource selfRes
     failwith fun err => throw (.custom here# err)
   let body := method.body selfObj argsData

--- a/AVM/Class/Translation/Logics.lean
+++ b/AVM/Class/Translation/Logics.lean
@@ -77,22 +77,23 @@ def MultiMethod.Message.logicFun
   (method : MultiMethod multiId)
   (msg : Message lab)
   (args : Logic.Args)
-  : Anoma.LogicM :=
-  check h : msg.data.id == .multiMethodId multiId
+  : Anoma.LogicM := do
+  docheck h : msg.data.id == .multiMethodId multiId
   let fargs : multiId.Args.type := cast (by simp! [eq_of_beq h]) msg.data.args
   let consumedResObjs := Logic.selectObjectResources args.consumed
   let createdResObjs := Logic.selectObjectResources args.created
   let argsConsumedSelves := consumedResObjs.take multiId.numObjectArgs
+  do
   let catch argsConsumedObjects : multiId.Selves := Label.MultiMethodId.ConsumedToSelves argsConsumedSelves
     failwith fun err => throw (.custom here# err)
-  check method.invariant msg argsConsumedObjects fargs
+  docheck method.invariant msg argsConsumedObjects fargs
   let prog := method.body argsConsumedObjects fargs
   let try vals : prog.params.Product := tryCast msg.data.vals
   let res : MultiMethodResult multiId := prog.value vals
   let valsObjs := prog.objects vals
   let fetchedObjValues := valsObjs.map (·.toObjectValue)
   let data := res.data
-  check argsConsumedSelves.length == multiId.numObjectArgs
+  docheck argsConsumedSelves.length == multiId.numObjectArgs
   let try (argsConstructedEph, consumedFetchedResObjs, .unit) :=
     consumedResObjs.drop multiId.numObjectArgs
     |>.splitsExact [data.numConstructed, valsObjs.length]
@@ -117,21 +118,21 @@ def MultiMethod.Message.logicFun
     |>.splitsExact [reassembled.length, data.numConstructed, data.numSelvesDestroyed, valsObjs.length]
   let messageValues := Program.messageValues prog vals
   let createdResMsgs := Logic.selectMessageResources args.created
-  check Logic.checkMessageResourceValues messageValues createdResMsgs
-    && Logic.checkResourceValues reassembled argsCreated.toList
-    && Logic.checkResourceValues constructedObjects argsConstructed.toList
-    && Logic.checkResourceValues constructedObjects argsConstructedEph.toList
-    && Logic.checkResourceValues consumedDestroyedObjects argsSelvesDestroyedEph.toList
-    && Logic.checkResourceValues fetchedObjValues consumedFetchedResObjs.toList
-    && Logic.checkResourceValues fetchedObjValues createdFetchedResObjs.toList
-    && Logic.checkResourcesPersistent argsConsumedSelves
+  docheck Logic.checkMessageResourceValues messageValues createdResMsgs
+  Logic.checkResourceValues reassembled argsCreated.toList
+  Logic.checkResourceValues constructedObjects argsConstructed.toList
+  Logic.checkResourceValues constructedObjects argsConstructedEph.toList
+  Logic.checkResourceValues consumedDestroyedObjects argsSelvesDestroyedEph.toList
+  Logic.checkResourceValues fetchedObjValues consumedFetchedResObjs.toList
+  Logic.checkResourceValues fetchedObjValues createdFetchedResObjs.toList
+  docheck Logic.checkResourcesPersistent argsConsumedSelves
     && Logic.checkResourcesPersistent argsCreated.toList
     && Logic.checkResourcesPersistent argsConstructed.toList
     && Logic.checkResourcesPersistent consumedFetchedResObjs.toList
     && Logic.checkResourcesPersistent createdFetchedResObjs.toList
     && Logic.checkResourcesEphemeral argsConstructedEph.toList
     && Logic.checkResourcesEphemeral argsSelvesDestroyedEph.toList
-  .true
+  Anoma.LogicM.true
 
 end AVM.Ecosystem
 
@@ -145,31 +146,36 @@ private def Constructor.Message.logicFun
   (constr : Class.Constructor classId constrId)
   (msg : Message lab)
   (args : Logic.Args)
-  : Anoma.LogicM :=
-  check h : msg.data.id == .classMember (Label.MemberId.constructorId constrId)
+  : Anoma.LogicM := do
+  docheck h : msg.data.id == .classMember (Label.MemberId.constructorId constrId)
   let argsData : constrId.Args.type := cast (by simp! [eq_of_beq h]) msg.data.args
   let body := constr.body argsData
   let try vals : body.params.Product := tryCast msg.data.vals
   let newObjData := body.value vals
-  let consumedResObjs := Logic.selectObjectResources args.consumed
-  let createdResObjs := Logic.selectObjectResources args.created
-  let! (newObjRes :: _) := createdResObjs
-  let! (consumedObjRes :: consumedFetchedResObjs) := consumedResObjs
-    failwith throw (.custom here# s!"consumedResObjs.length = {consumedResObjs.length}")
+  let consumedResObjs := Logic.selectObjectResources (args.consumed ++ if args.isConsumed then [args.self] else [])
+  let createdResObjs := Logic.selectObjectResources (args.created ++ if args.isConsumed then [] else [args.self])
+  dolet! (newObjRes :: _) := createdResObjs
+  dolet! (consumedObjRes :: consumedFetchedResObjs) := consumedResObjs
+    failwith throw (.custom here#
+    s!"consumedResObjs.length = {consumedResObjs.length}
+    args.consumed:\n{repr args.consumed}
+    args.created:\n{repr args.created}
+    self:\n{repr args.self}
+    self.isConsumed: {repr args.isConsumed}")
   let uid : ObjectId := newObjRes.nonce.value
   let messageValues := Program.messageValues body vals
-  let createdResMsgs := Logic.selectMessageResources args.created
+  let createdResMsgs := Logic.selectMessageResources (args.created  ++ if args.isConsumed then [] else [args.self])
   let valsObjs := body.objects vals
   let fetchedObjValues := valsObjs.map (·.toObjectValue)
   let newObjValue := newObjData.toObjectValue uid
-  check Logic.checkMessageResourceValues messageValues createdResMsgs
-    && Logic.checkResourceValues (newObjValue :: fetchedObjValues) consumedResObjs
-    && Logic.checkResourceValues (newObjValue :: fetchedObjValues) createdResObjs
-    && Logic.checkResourcesEphemeral [consumedObjRes]
-    && Logic.checkResourcesPersistent createdResObjs
-    && Logic.checkResourcesPersistent consumedFetchedResObjs
-    && constr.invariant msg argsData
-  .true
+  docheck Logic.checkMessageResourceValues messageValues createdResMsgs
+  Logic.checkResourceValues (newObjValue :: fetchedObjValues) consumedResObjs
+  Logic.checkResourceValues (newObjValue :: fetchedObjValues) createdResObjs
+  docheck Logic.checkResourcesEphemeral [consumedObjRes]
+  docheck Logic.checkResourcesPersistent createdResObjs
+  docheck Logic.checkResourcesPersistent consumedFetchedResObjs
+  docheck constr.invariant msg argsData
+  Anoma.LogicM.true
 
 /-- Creates a message logic function for a given destructor. -/
 private def Destructor.Message.logicFun
@@ -179,15 +185,15 @@ private def Destructor.Message.logicFun
   (destructor : Class.Destructor classId destructorId)
   (msg : Message lab)
   (args : Logic.Args)
-  : Anoma.LogicM :=
-  check h : msg.data.id == .classMember (Label.MemberId.destructorId destructorId)
+  : Anoma.LogicM := do
+  docheck h : msg.data.id == .classMember (Label.MemberId.destructorId destructorId)
   let argsData := cast (by simp! [eq_of_beq h]) msg.data.args
   let consumedResObjs := Logic.selectObjectResources args.consumed
   let createdResObjs := Logic.selectObjectResources args.created
-  let! (selfRes :: _) := consumedResObjs
-  let! (createdResObj :: createdFetchedResObjs) := createdResObjs
+  dolet! (selfRes :: _) := consumedResObjs
+  dolet! (createdResObj :: createdFetchedResObjs) := createdResObjs
   let catch selfObj : Object classId := Object.fromResource selfRes
-    failwith fun err => throw (.custom here# err)
+    failwith fun (err : String) => throw (.custom here# err)
   let body := destructor.body selfObj argsData
   let try vals : body.params.Product := tryCast msg.data.vals
   let messageValues := Program.messageValues body vals
@@ -195,14 +201,14 @@ private def Destructor.Message.logicFun
   let valsObjs := body.objects vals
   let fetchedObjValues := valsObjs.map (·.toObjectValue)
   let selfObjValue := selfObj.toObjectValue
-  check Logic.checkMessageResourceValues messageValues createdResMsgs
-    && Logic.checkResourceValues (selfObjValue :: fetchedObjValues) createdResObjs
-    && Logic.checkResourceValues (selfObjValue :: fetchedObjValues) consumedResObjs
-    && Logic.checkResourcesPersistent consumedResObjs
+  docheck Logic.checkMessageResourceValues messageValues createdResMsgs
+  Logic.checkResourceValues (selfObjValue :: fetchedObjValues) createdResObjs
+  Logic.checkResourceValues (selfObjValue :: fetchedObjValues) consumedResObjs
+  docheck Logic.checkResourcesPersistent consumedResObjs
     && Logic.checkResourcesEphemeral [createdResObj]
     && Logic.checkResourcesPersistent createdFetchedResObjs
     && destructor.invariant msg selfObj argsData
-  .true
+  Anoma.LogicM.true
 
 private def Method.Message.logicFun
   {lab : Ecosystem.Label}
@@ -211,8 +217,8 @@ private def Method.Message.logicFun
   (method : Class.Method classId methodId)
   (msg : Message lab)
   (args : Logic.Args)
-  : Anoma.LogicM :=
-  check h : msg.data.id == .classMember (Label.MemberId.methodId methodId)
+  : Anoma.LogicM := do
+  docheck h : msg.data.id == .classMember (Label.MemberId.methodId methodId)
   let argsData : methodId.Args.type := cast (by simp! [eq_of_beq h]) msg.data.args
   let consumedResObjs := Logic.selectObjectResources args.consumed
   let createdResObjs := Logic.selectObjectResources args.created
@@ -221,18 +227,19 @@ private def Method.Message.logicFun
     failwith fun err => throw (.custom here# err)
   let body := method.body selfObj argsData
   let try vals : body.params.Product := tryCast msg.data.vals
-  check method.invariant msg selfObj argsData
+  do -- TODO fix
+  docheck method.invariant msg selfObj argsData
   let createdObject : Object classId := body |>.value vals
   let messageValues := Program.messageValues body vals
   let createdResMsgs := Logic.selectMessageResources args.created
   let valsObjs := body.objects vals
   let fetchedObjValues := valsObjs.map (·.toObjectValue)
-  check Logic.checkMessageResourceValues messageValues createdResMsgs
-    && Logic.checkResourceValues (createdObject.toObjectValue :: fetchedObjValues) createdResObjs
-    && Logic.checkResourceValues (selfObj.toObjectValue :: fetchedObjValues) consumedResObjs
-    && Logic.checkResourcesPersistent consumedResObjs
+  docheck Logic.checkMessageResourceValues messageValues createdResMsgs
+  Logic.checkResourceValues (createdObject.toObjectValue :: fetchedObjValues) createdResObjs
+  Logic.checkResourceValues (selfObj.toObjectValue :: fetchedObjValues) consumedResObjs
+  docheck Logic.checkResourcesPersistent consumedResObjs
     && Logic.checkResourcesPersistent createdResObjs
-  .true
+  Anoma.LogicM.true
 
 private def Upgrade.Message.logicFun
   {lab : Ecosystem.Label}

--- a/AVM/Class/Translation/Logics.lean
+++ b/AVM/Class/Translation/Logics.lean
@@ -294,6 +294,9 @@ private def logicFun
   (args : Logic.Args)
   : Anoma.LogicM :=
   let try self : Object classId := Object.fromResource args.self
+    failwith throw (.custom here# s!"Failed to decode self to an Object:
+                                     {repr args.self}"
+      )
   check eco.classes classId |>.invariant self args
   match args.status with
   | Created => .true

--- a/AVM/Class/Translation/Logics.lean
+++ b/AVM/Class/Translation/Logics.lean
@@ -83,7 +83,6 @@ def MultiMethod.Message.logicFun
   let consumedResObjs := Logic.selectObjectResources args.consumed
   let createdResObjs := Logic.selectObjectResources args.created
   let argsConsumedSelves := consumedResObjs.take multiId.numObjectArgs
-  do
   let catch argsConsumedObjects : multiId.Selves := Label.MultiMethodId.ConsumedToSelves argsConsumedSelves
     failwith fun err => throw (.custom here# err)
   docheck method.invariant msg argsConsumedObjects fargs

--- a/AVM/Class/Translation/Logics.lean
+++ b/AVM/Class/Translation/Logics.lean
@@ -146,7 +146,7 @@ private def Constructor.Message.logicFun
   (constr : Class.Constructor classId constrId)
   (msg : Message lab)
   (args : Logic.Args)
-  : Anoma.LogicM := do
+  : Anoma.LogicM := Anoma.LogicM.withTrace here# "Constructor.Message.logicFun" do
   docheck h : msg.data.id == .classMember (Label.MemberId.constructorId constrId)
   let argsData : constrId.Args.type := cast (by simp! [eq_of_beq h]) msg.data.args
   let body := constr.body argsData

--- a/AVM/Class/Translation/Logics.lean
+++ b/AVM/Class/Translation/Logics.lean
@@ -185,7 +185,7 @@ private def Destructor.Message.logicFun
   (destructor : Class.Destructor classId destructorId)
   (msg : Message lab)
   (args : Logic.Args)
-  : Anoma.LogicM := do
+  : Anoma.LogicM := Anoma.LogicM.withTrace here# "Destructor.Message.logicFun" do
   docheck h : msg.data.id == .classMember (Label.MemberId.destructorId destructorId)
   let argsData := cast (by simp! [eq_of_beq h]) msg.data.args
   let consumedResObjs := Logic.selectObjectResources args.consumed
@@ -217,17 +217,16 @@ private def Method.Message.logicFun
   (method : Class.Method classId methodId)
   (msg : Message lab)
   (args : Logic.Args)
-  : Anoma.LogicM := do
+  : Anoma.LogicM := Anoma.LogicM.withTrace here# "Method.Message.logicFun" do
   docheck h : msg.data.id == .classMember (Label.MemberId.methodId methodId)
   let argsData : methodId.Args.type := cast (by simp! [eq_of_beq h]) msg.data.args
   let consumedResObjs := Logic.selectObjectResources args.consumed
   let createdResObjs := Logic.selectObjectResources args.created
-  let! (selfRes :: _) := consumedResObjs
+  dolet! (selfRes :: _) := consumedResObjs
   let catch selfObj : Object classId := Object.fromResource selfRes
     failwith fun err => throw (.custom here# err)
   let body := method.body selfObj argsData
   let try vals : body.params.Product := tryCast msg.data.vals
-  do -- TODO fix
   docheck method.invariant msg selfObj argsData
   let createdObject : Object classId := body |>.value vals
   let messageValues := Program.messageValues body vals

--- a/AVM/Class/Translation/Logics.lean
+++ b/AVM/Class/Translation/Logics.lean
@@ -3,6 +3,16 @@ import AVM.Message
 import AVM.Logic
 import AVM.Ecosystem
 
+namespace AVM.Logic
+
+def trivialLogicRef : Anoma.LogicRef := Anoma.LogicRef.mk "Anoma.TrivialLogic"
+
+def trivialLogic : Anoma.Logic :=
+  { reference := trivialLogicRef,
+    function := fun _ => .true }
+
+end AVM.Logic
+
 namespace AVM.Program
 
 structure MessageValue (lab : Ecosystem.Label) where
@@ -282,21 +292,22 @@ private def logicFun
   (eco : Ecosystem lab)
   (classId : lab.ClassId)
   (args : Logic.Args)
-  : Bool :=
+  : Anoma.LogicM :=
   let try self : Object classId := Object.fromResource args.self
   check eco.classes classId |>.invariant self args
   match args.status with
-  | Created => true
+  | Created => .true
   | Consumed =>
     if args.self.isPersistent && Logic.isObjectPreserved self.toObjectValue args.created then
-      true
+      .true
     else
       let! [consumedMessageResource] := Logic.selectMessageResources args.consumed
       -- Note: the success of the `try` below ensures that the message is "legal"
       -- for the consumed objects - it is from the same ecosystem
       let try msg : Message lab := Message.fromResource consumedMessageResource
-      self.uid ∈ msg.data.recipients
-      && Member.logicFun eco msg.data.id msg args
+      check self.uid ∈ msg.data.recipients
+        && Member.logicFun eco msg.data.id msg args
+      .true
 
 /-- The class logic that is the Resource Logic of each resource corresponding to
   an object of this class. -/

--- a/AVM/Class/Translation/Logics.lean
+++ b/AVM/Class/Translation/Logics.lean
@@ -3,16 +3,6 @@ import AVM.Message
 import AVM.Logic
 import AVM.Ecosystem
 
-namespace AVM.Logic
-
-def trivialLogicRef : Anoma.LogicRef := Anoma.LogicRef.mk "Anoma.TrivialLogic"
-
-def trivialLogic : Anoma.Logic :=
-  { reference := trivialLogicRef,
-    function := fun _ => .true }
-
-end AVM.Logic
-
 namespace AVM.Program
 
 structure MessageValue (lab : Ecosystem.Label) where
@@ -295,8 +285,7 @@ private def logicFun
   : Anoma.LogicM :=
   let try self : Object classId := Object.fromResource args.self
     failwith throw (.custom here# s!"Failed to decode self to an Object:
-                                     {repr args.self}"
-      )
+    {repr args.self}")
   check eco.classes classId |>.invariant self args
   match args.status with
   | Created => .true

--- a/AVM/Class/Translation/Logics.lean
+++ b/AVM/Class/Translation/Logics.lean
@@ -155,6 +155,7 @@ private def Constructor.Message.logicFun
   let createdResObjs := Logic.selectObjectResources args.created
   let! (newObjRes :: _) := createdResObjs
   let! (consumedObjRes :: consumedFetchedResObjs) := consumedResObjs
+    failwith throw (.custom here# s!"consumedResObjs.length = {consumedResObjs.length}")
   let uid : ObjectId := newObjRes.nonce.value
   let messageValues := Program.messageValues body vals
   let createdResMsgs := Logic.selectMessageResources args.created

--- a/AVM/Class/Translation/Logics.lean
+++ b/AVM/Class/Translation/Logics.lean
@@ -77,13 +77,14 @@ def MultiMethod.Message.logicFun
   (method : MultiMethod multiId)
   (msg : Message lab)
   (args : Logic.Args)
-  : Bool :=
+  : Anoma.LogicM :=
   check h : msg.data.id == .multiMethodId multiId
   let fargs : multiId.Args.type := cast (by simp! [eq_of_beq h]) msg.data.args
   let consumedResObjs := Logic.selectObjectResources args.consumed
   let createdResObjs := Logic.selectObjectResources args.created
   let argsConsumedSelves := consumedResObjs.take multiId.numObjectArgs
-  let try argsConsumedObjects : multiId.Selves := Label.MultiMethodId.ConsumedToSelves argsConsumedSelves
+  let catch argsConsumedObjects : multiId.Selves := Label.MultiMethodId.ConsumedToSelves argsConsumedSelves
+    failwith fun err => throw (.custom here# err)
   check method.invariant msg argsConsumedObjects fargs
   let prog := method.body argsConsumedObjects fargs
   let try vals : prog.params.Product := tryCast msg.data.vals
@@ -116,7 +117,7 @@ def MultiMethod.Message.logicFun
     |>.splitsExact [reassembled.length, data.numConstructed, data.numSelvesDestroyed, valsObjs.length]
   let messageValues := Program.messageValues prog vals
   let createdResMsgs := Logic.selectMessageResources args.created
-  Logic.checkMessageResourceValues messageValues createdResMsgs
+  check Logic.checkMessageResourceValues messageValues createdResMsgs
     && Logic.checkResourceValues reassembled argsCreated.toList
     && Logic.checkResourceValues constructedObjects argsConstructed.toList
     && Logic.checkResourceValues constructedObjects argsConstructedEph.toList
@@ -130,6 +131,7 @@ def MultiMethod.Message.logicFun
     && Logic.checkResourcesPersistent createdFetchedResObjs.toList
     && Logic.checkResourcesEphemeral argsConstructedEph.toList
     && Logic.checkResourcesEphemeral argsSelvesDestroyedEph.toList
+  .true
 
 end AVM.Ecosystem
 
@@ -143,7 +145,7 @@ private def Constructor.Message.logicFun
   (constr : Class.Constructor classId constrId)
   (msg : Message lab)
   (args : Logic.Args)
-  : Bool :=
+  : Anoma.LogicM :=
   check h : msg.data.id == .classMember (Label.MemberId.constructorId constrId)
   let argsData : constrId.Args.type := cast (by simp! [eq_of_beq h]) msg.data.args
   let body := constr.body argsData
@@ -159,13 +161,14 @@ private def Constructor.Message.logicFun
   let valsObjs := body.objects vals
   let fetchedObjValues := valsObjs.map (·.toObjectValue)
   let newObjValue := newObjData.toObjectValue uid
-  Logic.checkMessageResourceValues messageValues createdResMsgs
+  check Logic.checkMessageResourceValues messageValues createdResMsgs
     && Logic.checkResourceValues (newObjValue :: fetchedObjValues) consumedResObjs
     && Logic.checkResourceValues (newObjValue :: fetchedObjValues) createdResObjs
     && Logic.checkResourcesEphemeral [consumedObjRes]
     && Logic.checkResourcesPersistent createdResObjs
     && Logic.checkResourcesPersistent consumedFetchedResObjs
     && constr.invariant msg argsData
+  .true
 
 /-- Creates a message logic function for a given destructor. -/
 private def Destructor.Message.logicFun
@@ -175,14 +178,15 @@ private def Destructor.Message.logicFun
   (destructor : Class.Destructor classId destructorId)
   (msg : Message lab)
   (args : Logic.Args)
-  : Bool :=
+  : Anoma.LogicM :=
   check h : msg.data.id == .classMember (Label.MemberId.destructorId destructorId)
   let argsData := cast (by simp! [eq_of_beq h]) msg.data.args
   let consumedResObjs := Logic.selectObjectResources args.consumed
   let createdResObjs := Logic.selectObjectResources args.created
   let! (selfRes :: _) := consumedResObjs
   let! (createdResObj :: createdFetchedResObjs) := createdResObjs
-  let try selfObj : Object classId := Object.fromResource selfRes
+  let catch selfObj : Object classId := Object.fromResource selfRes
+    failwith fun err => throw (.custom here# err)
   let body := destructor.body selfObj argsData
   let try vals : body.params.Product := tryCast msg.data.vals
   let messageValues := Program.messageValues body vals
@@ -190,13 +194,14 @@ private def Destructor.Message.logicFun
   let valsObjs := body.objects vals
   let fetchedObjValues := valsObjs.map (·.toObjectValue)
   let selfObjValue := selfObj.toObjectValue
-  Logic.checkMessageResourceValues messageValues createdResMsgs
+  check Logic.checkMessageResourceValues messageValues createdResMsgs
     && Logic.checkResourceValues (selfObjValue :: fetchedObjValues) createdResObjs
     && Logic.checkResourceValues (selfObjValue :: fetchedObjValues) consumedResObjs
     && Logic.checkResourcesPersistent consumedResObjs
     && Logic.checkResourcesEphemeral [createdResObj]
     && Logic.checkResourcesPersistent createdFetchedResObjs
     && destructor.invariant msg selfObj argsData
+  .true
 
 private def Method.Message.logicFun
   {lab : Ecosystem.Label}
@@ -205,13 +210,14 @@ private def Method.Message.logicFun
   (method : Class.Method classId methodId)
   (msg : Message lab)
   (args : Logic.Args)
-  : Bool :=
+  : Anoma.LogicM :=
   check h : msg.data.id == .classMember (Label.MemberId.methodId methodId)
   let argsData : methodId.Args.type := cast (by simp! [eq_of_beq h]) msg.data.args
   let consumedResObjs := Logic.selectObjectResources args.consumed
   let createdResObjs := Logic.selectObjectResources args.created
   let! (selfRes :: _) := consumedResObjs
-  let try selfObj : Object classId := Object.fromResource selfRes
+  let catch selfObj : Object classId := Object.fromResource selfRes
+    failwith fun err => throw (.custom here# err)
   let body := method.body selfObj argsData
   let try vals : body.params.Product := tryCast msg.data.vals
   check method.invariant msg selfObj argsData
@@ -220,28 +226,32 @@ private def Method.Message.logicFun
   let createdResMsgs := Logic.selectMessageResources args.created
   let valsObjs := body.objects vals
   let fetchedObjValues := valsObjs.map (·.toObjectValue)
-  Logic.checkMessageResourceValues messageValues createdResMsgs
+  check Logic.checkMessageResourceValues messageValues createdResMsgs
     && Logic.checkResourceValues (createdObject.toObjectValue :: fetchedObjValues) createdResObjs
     && Logic.checkResourceValues (selfObj.toObjectValue :: fetchedObjValues) consumedResObjs
     && Logic.checkResourcesPersistent consumedResObjs
     && Logic.checkResourcesPersistent createdResObjs
+  .true
 
 private def Upgrade.Message.logicFun
   {lab : Ecosystem.Label}
   (classId : lab.ClassId)
   (args : Logic.Args)
-  : Bool :=
+  : Anoma.LogicM :=
   let! [selfRes] := Logic.selectObjectResources args.consumed
   let! [upgradedRes] := Logic.selectObjectResources args.created
-  let try selfObj : Object classId := Object.fromResource selfRes
-  let try upgradedObj : SomeObject := SomeObject.fromResource upgradedRes
-  selfObj.uid == upgradedObj.object.uid
+  let catch selfObj : Object classId := Object.fromResource selfRes
+    failwith fun err => throw (.custom here# err)
+  let catch upgradedObj : SomeObject := SomeObject.fromResource upgradedRes
+    failwith fun err => throw (.custom here# err)
+  check selfObj.uid == upgradedObj.object.uid
     && classId.label.isUpgradeable
     && upgradedObj.label == lab
     && upgradedObj.classId.label.name == classId.label.name
     && upgradedObj.classId.label.version > classId.label.version
     && selfRes.isPersistent
     && upgradedRes.isPersistent
+  .true
 
 private def Member.logicFun
   {lab : Ecosystem.Label}
@@ -249,7 +259,7 @@ private def Member.logicFun
   (member : lab.MemberId)
   (msg : Message lab)
   (args : Logic.Args)
-  : Bool :=
+  : Anoma.LogicM :=
   match member with
   | .multiMethodId multiId =>
     let method : Ecosystem.MultiMethod multiId := eco.multiMethods multiId
@@ -283,8 +293,11 @@ private def logicFun
   (classId : lab.ClassId)
   (args : Logic.Args)
   : Anoma.LogicM :=
-  let try self : Object classId := Object.fromResource args.self
-    failwith throw (.custom here# s!"Failed to decode self to an Object:
+  let catch self : Object classId := Object.fromResource args.self
+    failwith fun err => throw (.custom here# s!"Failed to decode self to an Object:
+    error: {err}
+    ------
+    Resource:
     {repr args.self}")
   check eco.classes classId |>.invariant self args
   match args.status with
@@ -298,8 +311,7 @@ private def logicFun
       -- for the consumed objects - it is from the same ecosystem
       let try msg : Message lab := Message.fromResource consumedMessageResource
       check self.uid ∈ msg.data.recipients
-        && Member.logicFun eco msg.data.id msg args
-      .true
+      Member.logicFun eco msg.data.id msg args
 
 /-- The class logic that is the Resource Logic of each resource corresponding to
   an object of this class. -/

--- a/AVM/Ecosystem/Label.lean
+++ b/AVM/Ecosystem/Label.lean
@@ -12,11 +12,12 @@ def ConsumedToSelves
   {lab : Ecosystem.Label}
   {multiId : lab.MultiMethodId}
   (consumed : List Anoma.Resource)
-  : Option multiId.Selves
+  : Except String multiId.Selves
   :=
   let try consumedVec : Vector Anoma.Resource multiId.numObjectArgs := consumed.toSizedVector
-  let mkConsumedObject (a : multiId.ObjectArgNames) : Option (Object a.classId) := Object.fromResource (consumedVec.get a.ix)
-  @FinEnum.decImageOption'
+  let mkConsumedObject (a : multiId.ObjectArgNames) : Except String (Object a.classId) := Object.fromResource (consumedVec.get a.ix)
+  @FinEnum.decImageExcept'
+    _
     multiId.ObjectArgNames
     multiId.ObjectArgNamesEnum
     (fun a => Object a.classId)

--- a/AVM/Ecosystem/Label/Base.lean
+++ b/AVM/Ecosystem/Label/Base.lean
@@ -132,6 +132,13 @@ inductive MemberId (lab : Ecosystem.Label) : Type where
 
 namespace MemberId
 
+instance instRepr {lab : Ecosystem.Label} : Repr (MemberId lab) where
+  reprPrec m _ :=
+    have := lab.multiMethodsRepr
+    match m with
+    | .multiMethodId f => s!"MultiMethod {repr f}"
+    | .classMember f => repr f
+
 instance instHashable {lab : Ecosystem.Label} : Hashable (MemberId lab) where
   hash m := Hashable.Mix.run do
     mix lab

--- a/AVM/Ecosystem/Label/Base.lean
+++ b/AVM/Ecosystem/Label/Base.lean
@@ -78,6 +78,8 @@ def label {lab : Ecosystem.Label} (classId : lab.ClassId) : Class.Label :=
 
 abbrev MemberId {lab : Ecosystem.Label} (c : lab.ClassId) := c.label.MemberId
 
+abbrev nat {lab : Ecosystem.Label} (c : lab.ClassId) : Nat := lab.classesEnum.equiv c
+
 instance MemberId.hasTypeRep {lab : Ecosystem.Label} {c : lab.ClassId} : TypeRep c.MemberId := Class.Label.MemberId.hasTypeRep c.label
 
 instance MemberId.hasBEq {lab : Ecosystem.Label} {c : lab.ClassId} : BEq c.MemberId := Class.Label.MemberId.hasBEq

--- a/AVM/Ecosystem/Label/Base.lean
+++ b/AVM/Ecosystem/Label/Base.lean
@@ -26,6 +26,9 @@ structure Label : Type 1 where
   [multiMethodsBEq : BEq MultiMethodId]
   [multiMethodsLawfulBEq : LawfulBEq MultiMethodId]
 
+instance Label.instRepr : Repr Label where
+  reprPrec l _ := s!"\{name := {l.name}; .. : Ecosystem.Label}"
+
 instance Label.instHashable : Hashable Label where
   hash l := hash l.name
 

--- a/AVM/Label.lean
+++ b/AVM/Label.lean
@@ -12,7 +12,13 @@ structure Object.Resource.Label where
   dynamicLabel : classId.label.DynamicLabel.Label.type
 
 instance : Repr Object.Resource.Label where
-  reprPrec _l _ := "Resource.Label TODO"
+  reprPrec l _ :=
+    have := l.label.classesRepr
+    s!"Resource.Label@\{
+      label := {repr l.label}
+      classId := {repr l.classId}
+      dynamicLabel := ?
+   }"
 
 instance : Hashable Object.Resource.Label where
   hash l := Hashable.Mix.run do

--- a/AVM/Label.lean
+++ b/AVM/Label.lean
@@ -23,7 +23,7 @@ instance : Repr Object.Resource.Label where
 instance : Hashable Object.Resource.Label where
   hash l := Hashable.Mix.run do
     mix l.label
-    mix (l.label.classesEnum.equiv l.classId)
+    mix l.classId.nat
     have := l.classId.label.DynamicLabel.Label.typeHashable
     mix l.dynamicLabel
 
@@ -52,7 +52,7 @@ instance : Hashable Resource.Label where
 instance : Repr Resource.Label where
   reprPrec lab _prec := match lab with
     | .object l => s!"object:{repr l}"
-    | .message _l => s!"message:TODO"
+    | .message l => s!"message:{repr l}"
 
 instance : TypeRep Resource.Label where
   rep := Rep.atomic "AVM.Resource.Label"

--- a/AVM/Label.lean
+++ b/AVM/Label.lean
@@ -11,6 +11,9 @@ structure Object.Resource.Label where
   /-- The dynamic label is used to put dynamic data into the Resource label -/
   dynamicLabel : classId.label.DynamicLabel.Label.type
 
+instance : Repr Object.Resource.Label where
+  reprPrec _l _ := "Resource.Label TODO"
+
 instance : Hashable Object.Resource.Label where
   hash l := Hashable.Mix.run do
     mix l.label
@@ -39,6 +42,11 @@ instance : Hashable Resource.Label where
     | .message s =>
       mix 1
       mix s
+
+instance : Repr Resource.Label where
+  reprPrec lab _prec := match lab with
+    | .object l => s!"object:{repr l}"
+    | .message _l => s!"message:TODO"
 
 instance : TypeRep Resource.Label where
   rep := Rep.atomic "AVM.Resource.Label"

--- a/AVM/Logic.lean
+++ b/AVM/Logic.lean
@@ -11,13 +11,22 @@ namespace AVM.Logic
 def filterOutDummy (resources : List Anoma.Resource) : List Anoma.Resource :=
   resources.filter (not ∘ Action.isDummyResource)
 
-def resourceValueEq (objValue : ObjectValue) (res : Anoma.Resource) : Bool :=
-  objValue.label === res.label &&
-  objValue.classId.label.logicRef == res.logicRef &&
-  objValue.data.quantity == res.quantity &&
-    let try resVal : Object.Resource.Value objValue.classId := tryCast res.value
-    resVal.privateFields == objValue.data.privateFields &&
-    resVal.uid == objValue.uid
+def resourceValueEq (objValue : ObjectValue) (res : Anoma.Resource) : Anoma.LogicM := do
+  docheck objValue.label === res.label
+    failwith
+    have := res.Label.typeRepr
+    throw (Anoma.LogicM.Error.custom here#
+    s!"label missmatch:
+    objValue: {repr objValue.label}
+    resource: {repr res.label}")
+  docheck objValue.classId.label.logicRef == res.logicRef
+    failwith throw (.custom here# "logicRef")
+  docheck objValue.data.quantity == res.quantity
+    failwith throw (.custom here# "quantity")
+  let try resVal : Object.Resource.Value objValue.classId := tryCast res.value
+  docheck resVal.privateFields == objValue.data.privateFields
+  docheck resVal.uid == objValue.uid
+  Anoma.LogicM.true
 
 def resourceIdEq (objValue : ObjectValue) (res : Anoma.Resource) : Bool :=
   let try resVal : Object.Resource.Value objValue.classId := tryCast res.value
@@ -27,10 +36,12 @@ def resourceIdEq (objValue : ObjectValue) (res : Anoma.Resource) : Bool :=
     quantity, value and labels of each resource match the corresponding object.
     This check is used in the constructor, destructor and method message logics.
     Dummy resources in the `resources` list are ignored. -/
-def checkResourceValues (objectValues : List ObjectValue) (resources : List Anoma.Resource) : Bool :=
+def checkResourceValues (objectValues : List ObjectValue) (resources : List Anoma.Resource) : Anoma.LogicM :=
   let resources' := Logic.filterOutDummy resources
-  objectValues.length == resources'.length
-    && List.and (List.zipWith resourceValueEq objectValues resources')
+  check objectValues.length == resources'.length
+    failwith (throw (.custom here# "length"))
+  do -- TODO fix notation
+  List.zipWithM' resourceValueEq objectValues resources'
 
 def checkResourcesEphemeral (resources : List Anoma.Resource) : Bool :=
   Logic.filterOutDummy resources |>.all Anoma.Resource.isEphemeral
@@ -46,4 +57,4 @@ def selectMessageResources (resources : List Anoma.Resource) : List Anoma.Resour
 
 def isObjectPreserved (obj : ObjectValue) (resources : List Anoma.Resource) : Bool :=
   let! [res] := resources.filter (resourceIdEq obj)
-  resourceValueEq obj res && res.isPersistent
+  (resourceValueEq obj res).isOk && res.isPersistent

--- a/AVM/Logic.lean
+++ b/AVM/Logic.lean
@@ -11,14 +11,14 @@ namespace AVM.Logic
 def filterOutDummy (resources : List Anoma.Resource) : List Anoma.Resource :=
   resources.filter (not ∘ Action.isDummyResource)
 
-def resourceValueEq (objValue : ObjectValue) (res : Anoma.Resource) : Anoma.LogicM := do
+def resourceValueEq (objValue : ObjectValue) (res : Anoma.Resource) : Anoma.LogicM := Anoma.LogicM.withTrace here# "resourceValueEq" do
   docheck objValue.label === res.label
-    failwith
+    failwith do
     have := res.Label.typeRepr
-    throw (Anoma.LogicM.Error.custom here#
-    s!"label missmatch:
-    objValue: {repr objValue.label}
-    resource: {repr res.label}")
+    Anoma.LogicM.throw here#
+        s!"label mismatch:
+        objValue: {repr objValue.label}
+        resource: {repr res.label}"
   docheck objValue.classId.label.logicRef == res.logicRef
     failwith throw (.custom here# "logicRef")
   docheck objValue.data.quantity == res.quantity
@@ -37,10 +37,10 @@ def resourceIdEq (objValue : ObjectValue) (res : Anoma.Resource) : Bool :=
     This check is used in the constructor, destructor and method message logics.
     Dummy resources in the `resources` list are ignored. -/
 def checkResourceValues (objectValues : List ObjectValue) (resources : List Anoma.Resource) : Anoma.LogicM :=
+  Anoma.LogicM.withTrace here# "checkResourceValues" do
   let resources' := Logic.filterOutDummy resources
-  check objectValues.length == resources'.length
+  docheck objectValues.length == resources'.length
     failwith (throw (.custom here# "length"))
-  do -- TODO fix notation
   List.zipWithM' resourceValueEq objectValues resources'
 
 def checkResourcesEphemeral (resources : List Anoma.Resource) : Bool :=

--- a/AVM/Logic.lean
+++ b/AVM/Logic.lean
@@ -12,13 +12,13 @@ def filterOutDummy (resources : List Anoma.Resource) : List Anoma.Resource :=
   resources.filter (not ∘ Action.isDummyResource)
 
 def resourceValueEq (objValue : ObjectValue) (res : Anoma.Resource) : Anoma.LogicM := Anoma.LogicM.withTrace here# "resourceValueEq" do
-  docheck objValue.label === res.label
-    failwith do
-    have := res.Label.typeRepr
-    Anoma.LogicM.throw here#
-        s!"label mismatch:
-        objValue: {repr objValue.label}
-        resource: {repr res.label}"
+  let try resLabel : Resource.Label := tryCast res.label
+    failwith Anoma.LogicM.throw here# "cast label"
+  dolet! (Resource.Label.object (oresLabel : Object.Resource.Label)) := resLabel
+    failwith Anoma.LogicM.throw here# "cast label"
+  docheck oresLabel.label == objValue.label
+    failwith Anoma.LogicM.throw here# "ecosystem label"
+  -- FIXME check classId. Also, what to do with dynamic label
   docheck objValue.classId.label.logicRef == res.logicRef
     failwith throw (.custom here# "logicRef")
   docheck objValue.data.quantity == res.quantity

--- a/AVM/Logic.lean
+++ b/AVM/Logic.lean
@@ -18,7 +18,11 @@ def resourceValueEq (objValue : ObjectValue) (res : Anoma.Resource) : Anoma.Logi
     failwith Anoma.LogicM.throw here# "cast label"
   docheck oresLabel.label == objValue.label
     failwith Anoma.LogicM.throw here# "ecosystem label"
-  -- FIXME check classId. Also, what to do with dynamic label
+  docheck oresLabel.classId.nat == objValue.classId.nat
+    failwith Anoma.LogicM.throw here# "classId"
+  let y := objValue.data.privateFields
+  docheck oresLabel.dynamicLabel === objValue.data.dynamicLabel
+    failwith Anoma.LogicM.throw here# "dynamic label"
   docheck objValue.classId.label.logicRef == res.logicRef
     failwith throw (.custom here# "logicRef")
   docheck objValue.data.quantity == res.quantity

--- a/AVM/Logic.lean
+++ b/AVM/Logic.lean
@@ -14,7 +14,7 @@ def filterOutDummy (resources : List Anoma.Resource) : List Anoma.Resource :=
 def resourceValueEq (objValue : ObjectValue) (res : Anoma.Resource) : Anoma.LogicM := Anoma.LogicM.withTrace here# "resourceValueEq" do
   let try resLabel : Resource.Label := tryCast res.label
     failwith Anoma.LogicM.throw here# "cast label"
-  dolet! (Resource.Label.object (oresLabel : Object.Resource.Label)) := resLabel
+  let! (Resource.Label.object (oresLabel : Object.Resource.Label)) := resLabel
     failwith Anoma.LogicM.throw here# "cast label"
   docheck oresLabel.label == objValue.label
     failwith Anoma.LogicM.throw here# "ecosystem label"

--- a/AVM/Logic/Base.lean
+++ b/AVM/Logic/Base.lean
@@ -10,6 +10,6 @@ def trivialLogicRef : Anoma.LogicRef := Anoma.LogicRef.mk "Anoma.TrivialLogic"
 
 def trivialLogic : Anoma.Logic :=
   { reference := trivialLogicRef,
-    function := fun _ => true }
+    function := fun _ => .true }
 
 abbrev builtinLogics : List Anoma.Logic := [trivialLogic]

--- a/AVM/Logic/Base.lean
+++ b/AVM/Logic/Base.lean
@@ -1,5 +1,6 @@
 import Anoma
 import AVM.Ecosystem.Label.Base
+import AVM.Action.DummyResource
 
 namespace AVM.Logic
 
@@ -12,4 +13,4 @@ def trivialLogic : Anoma.Logic :=
   { reference := trivialLogicRef,
     function := fun _ => .true }
 
-abbrev builtinLogics : List Anoma.Logic := [trivialLogic]
+abbrev builtinLogics : List Anoma.Logic := [trivialLogic, AVM.Action.dummyResourceLogic]

--- a/AVM/Message/Base.lean
+++ b/AVM/Message/Base.lean
@@ -10,16 +10,7 @@ structure Message (lab : Ecosystem.Label) : Type 1 where
   signatures : List Signature
 
 instance {lab : Ecosystem.Label} : Repr (Message lab) where
-  reprPrec r _ :=
-    have := r.Vals.typeRepr
-    have := r.id.Args.typeRepr
-    s!"Message@\{
-      id := {repr r.id}
-      vals := {repr r.vals}
-      args := {repr r.args}
-      logicRef := {repr r.logicRef}
-      recipients := {repr r.recipients}
-    }"
+  reprPrec r _ := repr r.data
 
 def Message.rawSignatures {lab : Ecosystem.Label} (msg : Message lab) : List Nat :=
   msg.signatures.map Signature.raw

--- a/AVM/Message/Base.lean
+++ b/AVM/Message/Base.lean
@@ -9,6 +9,18 @@ structure Message (lab : Ecosystem.Label) : Type 1 where
   /-- Signatures for `data`. -/
   signatures : List Signature
 
+instance {lab : Ecosystem.Label} : Repr (Message lab) where
+  reprPrec r _ :=
+    have := r.Vals.typeRepr
+    have := r.id.Args.typeRepr
+    s!"Message@\{
+      id := {repr r.id}
+      vals := {repr r.vals}
+      args := {repr r.args}
+      logicRef := {repr r.logicRef}
+      recipients := {repr r.recipients}
+    }"
+
 def Message.rawSignatures {lab : Ecosystem.Label} (msg : Message lab) : List Nat :=
   msg.signatures.map Signature.raw
 
@@ -28,7 +40,7 @@ structure SomeMessage : Type 1 where
   message : Message label
 
 instance SomeMessage.instRepr : Repr SomeMessage where
-  reprPrec _m _ := s!"SomeMessage TODO"
+  reprPrec m _ := repr m.message
 
 instance SomeMessage.instHashable : Hashable SomeMessage where
   hash m := Hashable.Mix.run do

--- a/AVM/Message/Base.lean
+++ b/AVM/Message/Base.lean
@@ -27,6 +27,9 @@ structure SomeMessage : Type 1 where
   {label : Ecosystem.Label}
   message : Message label
 
+instance SomeMessage.instRepr : Repr SomeMessage where
+  reprPrec _m _ := s!"SomeMessage TODO"
+
 instance SomeMessage.instHashable : Hashable SomeMessage where
   hash m := Hashable.Mix.run do
     mix m.label

--- a/AVM/Message/Data.lean
+++ b/AVM/Message/Data.lean
@@ -18,6 +18,17 @@ structure MessageData (lab : Ecosystem.Label) : Type 1 where
   /-- The recipients of the message. -/
   recipients : List ObjectId
 
+instance {lab : Ecosystem.Label} : Repr (MessageData lab) where
+  reprPrec r _ :=
+    have := r.Vals.typeRepr
+    have := r.id.Args.typeRepr
+    s!"Message@\{
+      id := {repr r.id}
+      vals := {repr r.vals}
+      args := {repr r.args}
+      recipients := {repr r.recipients}
+    }"
+
 instance MessageData.hasTypeRep (lab : Ecosystem.Label) : TypeRep (MessageData lab) where
   rep := Rep.composite "AVM.MessageData" [Rep.atomic lab.name]
 

--- a/AVM/Object.lean
+++ b/AVM/Object.lean
@@ -124,6 +124,9 @@ structure Object.Resource.SomeValue where
   uid : Anoma.ObjectId
   privateFields : classId.label.PrivateFields.type
 
+instance : Repr Object.Resource.SomeValue where
+  reprPrec _v _ := s!"SomeValue TODO"
+
 instance : Hashable Object.Resource.SomeValue where
   hash v := Hashable.Mix.run do
     mix v.lab

--- a/AVM/Object.lean
+++ b/AVM/Object.lean
@@ -125,7 +125,14 @@ structure Object.Resource.SomeValue where
   privateFields : classId.label.PrivateFields.type
 
 instance : Repr Object.Resource.SomeValue where
-  reprPrec _v _ := s!"SomeValue TODO"
+  reprPrec v _ :=
+    have := v.lab.classesRepr
+    have := v.classId.label.PrivateFields.typeRepr
+    s!"SomeValue@\{
+      classId := {repr v.classId}
+      uid := {repr v.uid}
+      privateFields := {repr v.privateFields}
+    }"
 
 instance : Hashable Object.Resource.SomeValue where
   hash v := Hashable.Mix.run do

--- a/AVM/Object.lean
+++ b/AVM/Object.lean
@@ -124,6 +124,18 @@ structure Object.Resource.SomeValue where
   uid : Anoma.ObjectId
   privateFields : classId.label.PrivateFields.type
 
+def Object.Resource.SomeValue.toValue
+  {lab : Ecosystem.Label}
+  {classId : lab.ClassId}
+  (v : SomeValue)
+  : Except String (Object.Resource.Value classId) :=
+  check v.lab == lab
+    failwith (throw s!"{repr here#}: Labels do not match")
+  let try privateFields := tryCast v.privateFields
+  pure {
+    uid := v.uid
+    privateFields }
+
 instance : Repr Object.Resource.SomeValue where
   reprPrec v _ :=
     have := v.lab.classesRepr
@@ -196,8 +208,18 @@ def Object.fromResource
     failwith throw s!"{repr here#}"
   check (res.logicRef == c.label.logicRef)
     failwith throw s!"{repr here#}"
-  let try value : Object.Resource.Value c := tryCast res.value
-    failwith throw s!"{repr here#}: Failed to cast value"
+  let try svalue : Object.Resource.SomeValue := tryCast res.value
+    failwith
+      have := res.Val.typeRepr
+      have := lab.classesRepr
+      let x : TypeRep (Object.Resource.Value c) := inferInstance
+      throw s!"{repr here#}: Failed to cast value
+      classId: {repr c}
+      classLabel: {repr (lab.classLabel c)}
+      resource typeRep: {repr res.Val.typeTypeRep.rep}
+      expected typeRep: {repr x.rep}
+      value:\n {repr res.value}"
+  let catch value : Object.Resource.Value c := svalue.toValue
   pure { uid := value.uid
          data := { quantity := res.quantity
                    privateFields := value.privateFields }

--- a/AVM/Object.lean
+++ b/AVM/Object.lean
@@ -187,28 +187,33 @@ def Object.fromResource
   {lab : Ecosystem.Label}
   {c : lab.ClassId}
   (res : Anoma.Resource)
-  : Option (Object c) :=
+  : Except String (Object c) :=
   let try resLab : AVM.Resource.Label := tryCast res.label
+    failwith throw s!"{repr here#}"
   let try objLab := Resource.Label.getObjectResourceLabel resLab
+    failwith throw s!"{repr here#}"
   check (objLab.label == lab)
+    failwith throw s!"{repr here#}"
   check (res.logicRef == c.label.logicRef)
+    failwith throw s!"{repr here#}"
   let try value : Object.Resource.Value c := tryCast res.value
-  some {  uid := value.uid
-          data := { quantity := res.quantity
-                    privateFields := value.privateFields }
-          nonce := res.nonce }
+    failwith throw s!"{repr here#}: Failed to cast value"
+  pure { uid := value.uid
+         data := { quantity := res.quantity
+                   privateFields := value.privateFields }
+         nonce := res.nonce }
 
 def SomeObject.fromResource
   (res : Anoma.Resource)
-  : Option SomeObject :=
+  : Except String SomeObject :=
   let try resLab : AVM.Resource.Label := tryCast res.label
   let try objLab := Resource.Label.getObjectResourceLabel resLab
   let label : Ecosystem.Label := objLab.label
   let classId := objLab.classId
-  let try object := @Object.fromResource label classId res
-  some { label
-         classId
-         object }
+  let catch object := @Object.fromResource label classId res
+  .ok { label
+        classId
+        object }
 
 def Resource.isSomeObject (res : Anoma.Resource) : Bool :=
-  Option.isSome (SomeObject.fromResource res)
+  Except.isOk (SomeObject.fromResource res)

--- a/AVM/Object.lean
+++ b/AVM/Object.lean
@@ -19,7 +19,7 @@ instance ObjectData.instHashable
   : Hashable (ObjectData c) where
   hash v := Hashable.Mix.run do
     mix lab
-    mix (lab.classesEnum.equiv c)
+    mix c.nat
     mix v.quantity
     have := c.label.PrivateFields.typeHashable
     mix v.privateFields
@@ -30,6 +30,9 @@ instance ObjectData.inhabited {lab : Ecosystem.Label} (c : lab.ClassId) : Inhabi
 
 instance ObjectData.hasTypeRep {lab : Ecosystem.Label} (c : lab.ClassId) : TypeRep (ObjectData c) where
   rep := Rep.composite "AVM.ObjectData" [Rep.atomic lab.name, Rep.atomic c.label.name]
+
+abbrev ObjectData.dynamicLabel {lab : Ecosystem.Label} {c : lab.ClassId} (objData : ObjectData c) : c.label.DynamicLabel.Label.type :=
+  c.label.DynamicLabel.mkDynamicLabel objData.privateFields
 
 structure SomeObjectData : Type 1 where
   {label : Ecosystem.Label}
@@ -80,7 +83,7 @@ structure Object {lab : Ecosystem.Label} (c : lab.ClassId) : Type where
 instance Object.instHashable {lab : Ecosystem.Label} (c : lab.ClassId) : Hashable (Object c) where
   hash v := Hashable.Mix.run do
     mix lab
-    mix (lab.classesEnum.equiv c)
+    mix c.nat
     mix v.uid
     mix v.nonce
     mix v.data
@@ -149,7 +152,7 @@ instance : Repr Object.Resource.SomeValue where
 instance : Hashable Object.Resource.SomeValue where
   hash v := Hashable.Mix.run do
     mix v.lab
-    mix (v.lab.classesEnum.equiv v.classId)
+    mix v.classId.nat
     mix v.uid
     have := v.classId.label.PrivateFields.typeHashable
     mix v.privateFields
@@ -159,10 +162,8 @@ instance : TypeRep Object.Resource.SomeValue where
 
 instance : BEq Object.Resource.SomeValue where
   beq v1 v2 :=
-    let c1 := v1.lab.classesEnum.equiv.toFun
-    let c2 := v2.lab.classesEnum.equiv.toFun
     v1.lab.name == v2.lab.name
-    && (c1 v1.classId).val == (c2 v2.classId).val
+    && v1.classId.nat == v2.classId.nat
     && v1.uid == v2.uid
     && v1.privateFields === v2.privateFields
 
@@ -172,7 +173,6 @@ def SomeObject.toResource
   (ephemeral : Bool)
   : Anoma.Resource :=
   let classId := sobj.classId
-  let clab := classId.label
   let label := sobj.label
   let obj : Object classId := sobj.object
   { Label := ⟨AVM.Resource.Label⟩,
@@ -180,7 +180,7 @@ def SomeObject.toResource
       Resource.Label.object
             { label
               classId
-              dynamicLabel := clab.DynamicLabel.mkDynamicLabel obj.data.privateFields }
+              dynamicLabel := obj.data.dynamicLabel }
     logicRef := classId.label.logicRef,
     quantity := obj.data.quantity,
     Val := ⟨Object.Resource.SomeValue⟩,

--- a/AVM/Program.lean
+++ b/AVM/Program.lean
@@ -65,7 +65,6 @@ inductive Program.{u} (scope : Scope.Label) (ReturnType : Type u) : Type (max u 
     return
     (val : ReturnType)
     : Program scope ReturnType
-
   | /-- Log a message. -/
     log
     (msg : String)

--- a/AVM/Program/Parameters.lean
+++ b/AVM/Program/Parameters.lean
@@ -40,7 +40,7 @@ def Product (params : Program.Parameters) : Type :=
     Σ (r : Nat), Program.Parameters.Product (rest r)
 
 instance Product.instRepr {params : Program.Parameters} : Repr (Product params) where
-  reprPrec _ _ := "Product TODO"
+  reprPrec _ _ := "Product {..}"
 
 def Product.hashHelper {params : Program.Parameters} (p : params.Product) : Hashable.Mix := do
   match params with

--- a/AVM/Program/Parameters.lean
+++ b/AVM/Program/Parameters.lean
@@ -39,6 +39,9 @@ def Product (params : Program.Parameters) : Type :=
   | .rand rest =>
     Σ (r : Nat), Program.Parameters.Product (rest r)
 
+instance Product.instRepr {params : Program.Parameters} : Repr (Product params) where
+  reprPrec _ _ := "Product TODO"
+
 def Product.hashHelper {params : Program.Parameters} (p : params.Product) : Hashable.Mix := do
   match params with
   | .empty =>

--- a/AVM/Task/Translation.lean
+++ b/AVM/Task/Translation.lean
@@ -26,8 +26,8 @@ private def resolveParameters (params : Program.Parameters) (cont : params.Produ
   | .empty => cont PUnit.unit
   | .fetch (classId := classId) p ps =>
     Anoma.Program.queryResource (Anoma.Program.ResourceQuery.mk p) (fun res =>
-      let try obj : Object classId := Object.fromResource res
-          failwith Anoma.Program.raise <| Anoma.Program.Error.typeError ("expected object of class " ++ classId.label.name)
+      let catch obj : Object classId := Object.fromResource res
+          failwith fun _err => Anoma.Program.raise <| Anoma.Program.Error.typeError ("expected object of class " ++ classId.label.name)
       resolveParameters (ps obj) (fun vals => cont ⟨obj, vals⟩))
   | .genId ps =>
     Anoma.Program.genObjectId (fun objId =>

--- a/Anoma/Logic.lean
+++ b/Anoma/Logic.lean
@@ -5,13 +5,12 @@ namespace Anoma
 inductive Logic.Error : Type where
   | rawError (pos : FilePosition)
   | custom (pos : FilePosition) (msg : String)
-  -- | rawError
 
 instance : Repr Logic.Error where
   reprPrec e _ :=
     match e with
     | .rawError p => repr p
-    | .custom p msg => s!"{repr p}: {msg}"
+    | .custom p msg => s!"{repr p}\n{msg}"
 
 structure Logic.Args : Type 2 where
   self : Resource

--- a/Anoma/Logic.lean
+++ b/Anoma/Logic.lean
@@ -2,15 +2,26 @@ import Anoma.Resource
 
 namespace Anoma
 
-inductive LogicM.Error : Type where
-  | onlyPosition (pos : FilePosition)
-  | custom (pos : FilePosition) (msg : String)
+structure LogicM.Error : Type where
+  stackTrace : List String
+  position : FilePosition
+  reason : String
+
+def LogicM.Error.onlyPosition (position : FilePosition) : LogicM.Error where
+  position
+  stackTrace := []
+  reason := "<no explicit reason>"
+
+def LogicM.Error.custom (position : FilePosition) (reason : String) : LogicM.Error where
+  position
+  stackTrace := []
+  reason
 
 instance : Repr LogicM.Error where
   reprPrec e _ :=
-    match e with
-    | .onlyPosition p => repr p
-    | .custom p msg => s!"{repr p}\n{msg}"
+    s!"Error at {repr e.position}
+      Reason:\n{e.reason}
+      Trace:\n{e.stackTrace.unlines}"
 
 structure Logic.Args : Type 2 where
   self : Resource
@@ -21,11 +32,35 @@ structure Logic.Args : Type 2 where
   Data : SomeType.{0}
   data : Data.type
 
+-- The StackTrace is only used in the error message. It should never be used to
+-- branch on a computation.
+abbrev LogicM.StackTrace := List String
+
 def Logic.Args.isConsumed (d : Logic.Args) := d.status.isConsumed
 
-abbrev LogicM : Type := Except LogicM.Error Unit
+abbrev LogicM : Type := EStateM LogicM.Error LogicM.StackTrace Unit
 
 abbrev LogicM.true : LogicM := pure .unit
+
+abbrev LogicM.eval (l : LogicM) : Option LogicM.Error :=
+  match l.run ∅ with
+  | .error e _ => some e
+  | .ok _ _ => none
+
+abbrev LogicM.withTrace (here : FilePosition) (str : String) (l : LogicM) : LogicM := do
+  let old ← get
+  set (s!"{repr here}: {str}" :: old)
+  l
+  set old
+
+abbrev LogicM.isOk (l : LogicM) : Bool := l.eval.isNone
+
+def LogicM.throw (position : FilePosition) (reason : String) : LogicM := do
+  let s ← get
+  MonadExcept.throw
+    { reason
+      position
+      stackTrace := s.reverse }
 
 def LogicFunction : Type 2 := Logic.Args → LogicM
 

--- a/Anoma/Logic.lean
+++ b/Anoma/Logic.lean
@@ -13,7 +13,11 @@ structure Logic.Args : Type 2 where
 
 def Logic.Args.isConsumed (d : Logic.Args) := d.status.isConsumed
 
-abbrev LogicFunction : Type 2 := Logic.Args → Bool
+abbrev LogicM : Type := Except String Unit
+
+abbrev LogicM.true : LogicM := pure .unit
+
+def LogicFunction : Type 2 := Logic.Args → LogicM
 
 structure Logic where
   reference : LogicRef

--- a/Anoma/Logic.lean
+++ b/Anoma/Logic.lean
@@ -2,14 +2,14 @@ import Anoma.Resource
 
 namespace Anoma
 
-inductive Logic.Error : Type where
-  | rawError (pos : FilePosition)
+inductive LogicM.Error : Type where
+  | onlyPosition (pos : FilePosition)
   | custom (pos : FilePosition) (msg : String)
 
-instance : Repr Logic.Error where
+instance : Repr LogicM.Error where
   reprPrec e _ :=
     match e with
-    | .rawError p => repr p
+    | .onlyPosition p => repr p
     | .custom p msg => s!"{repr p}\n{msg}"
 
 structure Logic.Args : Type 2 where
@@ -23,7 +23,7 @@ structure Logic.Args : Type 2 where
 
 def Logic.Args.isConsumed (d : Logic.Args) := d.status.isConsumed
 
-abbrev LogicM : Type := Except Logic.Error Unit
+abbrev LogicM : Type := Except LogicM.Error Unit
 
 abbrev LogicM.true : LogicM := pure .unit
 

--- a/Anoma/Logic.lean
+++ b/Anoma/Logic.lean
@@ -2,6 +2,17 @@ import Anoma.Resource
 
 namespace Anoma
 
+inductive Logic.Error : Type where
+  | rawError (pos : FilePosition)
+  | custom (pos : FilePosition) (msg : String)
+  -- | rawError
+
+instance : Repr Logic.Error where
+  reprPrec e _ :=
+    match e with
+    | .rawError p => repr p
+    | .custom p msg => s!"{repr p}: {msg}"
+
 structure Logic.Args : Type 2 where
   self : Resource
   status : ConsumedCreated
@@ -13,7 +24,7 @@ structure Logic.Args : Type 2 where
 
 def Logic.Args.isConsumed (d : Logic.Args) := d.status.isConsumed
 
-abbrev LogicM : Type := Except String Unit
+abbrev LogicM : Type := Except Logic.Error Unit
 
 abbrev LogicM.true : LogicM := pure .unit
 

--- a/Anoma/Nonce.lean
+++ b/Anoma/Nonce.lean
@@ -6,7 +6,7 @@ namespace Anoma
 
 structure Nonce where
  value : Nat
- deriving BEq, Hashable
+ deriving BEq, Hashable, Repr
 
 instance Nonce.hasTypeRep : TypeRep Nonce where
   rep := Rep.atomic "Nonce"

--- a/Anoma/Program.lean
+++ b/Anoma/Program.lean
@@ -29,7 +29,7 @@ structure Program.Error.BalanceCheck : Type 2 where
 inductive Program.Error : Type 2 where
   | identityError (msg : String)
   | storageError (msg : String)
-  | logicFailed (logRef : LogicRef) (reason : Logic.Error)
+  | logicFailed (logRef : LogicRef) (reason : LogicM.Error)
   | missingLogic (ref : LogicRef)
   | balanceCheck (err : Program.Error.BalanceCheck)
   | typeError (msg : String)

--- a/Anoma/Program.lean
+++ b/Anoma/Program.lean
@@ -18,12 +18,20 @@ inductive StorageValue where
 structure Program.ResourceQuery where
   uid : ObjectId
 
-inductive Program.Error : Type where
+structure Program.Error.BalanceCheck : Type 2 where
+  consumed : List Resource
+  created : List Resource
+  kind : Resource.Kind
+  kindConsumed : List Resource
+  kindCreated : List Resource
+  deriving Repr
+
+inductive Program.Error : Type 2 where
   | identityError (msg : String)
   | storageError (msg : String)
   | logicFailed (logRef : LogicRef)
   | missingLogic (ref : LogicRef)
-  | balanceCheck (msg : String)
+  | balanceCheck (err : Program.Error.BalanceCheck)
   | typeError (msg : String)
   | userError
   deriving Repr

--- a/Anoma/Program.lean
+++ b/Anoma/Program.lean
@@ -29,7 +29,7 @@ structure Program.Error.BalanceCheck : Type 2 where
 inductive Program.Error : Type 2 where
   | identityError (msg : String)
   | storageError (msg : String)
-  | logicFailed (logRef : LogicRef)
+  | logicFailed (logRef : LogicRef) (reason : String)
   | missingLogic (ref : LogicRef)
   | balanceCheck (err : Program.Error.BalanceCheck)
   | typeError (msg : String)

--- a/Anoma/Program.lean
+++ b/Anoma/Program.lean
@@ -29,7 +29,7 @@ structure Program.Error.BalanceCheck : Type 2 where
 inductive Program.Error : Type 2 where
   | identityError (msg : String)
   | storageError (msg : String)
-  | logicFailed (logRef : LogicRef) (reason : String)
+  | logicFailed (logRef : LogicRef) (reason : Logic.Error)
   | missingLogic (ref : LogicRef)
   | balanceCheck (err : Program.Error.BalanceCheck)
   | typeError (msg : String)

--- a/Anoma/Resource.lean
+++ b/Anoma/Resource.lean
@@ -58,7 +58,12 @@ structure Kind : Type 2 where
   logicRef : LogicRef
 
 instance Kind.instRepr : Repr Kind where
-  reprPrec k _ := s!"Kind@\{ label := ??? \nlogicRef:= {repr k.logicRef}"
+  reprPrec k _ :=
+    have := k.Label.typeRepr
+    s!"Kind@\{
+      label := {repr k.label}
+      logicRef:= {repr k.logicRef}
+    }"
 
 def kind (r : Resource) : Kind where
   Label := r.Label

--- a/Anoma/Resource.lean
+++ b/Anoma/Resource.lean
@@ -24,6 +24,17 @@ structure Resource : Type 2 where
 
 namespace Resource
 
+def h (x : Lean.Json) : String := toString x
+
+instance instRepr : Repr Resource where
+  reprPrec r _ :=
+    s!"Resource@\{
+    logicRef := {repr r.logicRef}
+    quantity := {repr r.quantity}
+    ephemeral := {repr r.ephemeral}
+    nonce := {repr r.nonce}
+    }"
+
 instance instHashable : Hashable Resource where
   hash r :=
     Hashable.Mix.run do
@@ -37,10 +48,13 @@ instance instHashable : Hashable Resource where
       mix r.nonce
       mix r.nullifierKeyCommitment
 
-structure Kind.{v} : Type (v + 1) where
-  Label : SomeType.{v}
+structure Kind : Type 2 where
+  Label : SomeType.{1}
   label : Label.type
   logicRef : LogicRef
+
+instance Kind.instRepr : Repr Kind where
+  reprPrec k _ := s!"Kind@\{ label := ??? \nlogicRef:= {repr k.logicRef}"
 
 def kind (r : Resource) : Kind where
   Label := r.Label

--- a/Anoma/Resource.lean
+++ b/Anoma/Resource.lean
@@ -28,11 +28,15 @@ def h (x : Lean.Json) : String := toString x
 
 instance instRepr : Repr Resource where
   reprPrec r _ :=
+    have := r.Label.typeRepr
+    have := r.Val.typeRepr
     s!"Resource@\{
-    logicRef := {repr r.logicRef}
-    quantity := {repr r.quantity}
-    ephemeral := {repr r.ephemeral}
-    nonce := {repr r.nonce}
+      label := {repr r.label}
+      value := {repr r.value}
+      logicRef := {repr r.logicRef}
+      quantity := {repr r.quantity}
+      ephemeral := {repr r.ephemeral}
+      nonce := {repr r.nonce}
     }"
 
 instance instHashable : Hashable Resource where

--- a/Anoma/Simulator.lean
+++ b/Anoma/Simulator.lean
@@ -32,10 +32,10 @@ abbrev RmState.ini (logics : Std.HashMap LogicRef LogicFunction) (gen : StdGen :
 
 /-- The evaluation monad -/
 abbrev RunM (a : Type 2) : Type 2 :=
-  EStateM (ULift Program.Error) RmState a
+  EStateM (Program.Error) RmState a
 
 def throw' {α : Type _} (e : Program.Error) : RunM α :=
-  throw (ULift.up e)
+  throw e
 
 /-- checks that consumed and created resources of the same kind are balanced -/
 def checkDelta (actions : List SplitAction) : RunM PUnit := do
@@ -45,14 +45,20 @@ def checkDelta (actions : List SplitAction) : RunM PUnit := do
   let consumedByKind := mkMap consumed
   let createdByKind := mkMap created
   let kinds : Std.HashSet Resource.Kind := Std.HashSet.ofList (consumedByKind.keys ++ createdByKind.keys)
+  let getResourcesOfKind (m : Std.HashMap Resource.Kind (List Resource)) (k : Resource.Kind) : List Resource :=
+    m.get? k |>.getD []
   let getQuantityOfKind (m : Std.HashMap Resource.Kind (List Resource)) (k : Resource.Kind) : Nat :=
-    m.get? k |>.getD [] |>.map (·.quantity) |>.sum
+    getResourcesOfKind m k |>.map (·.quantity) |>.sum
   for kind in kinds do
     let numConsumed := getQuantityOfKind consumedByKind kind
     let numCreated := getQuantityOfKind createdByKind kind
     if numConsumed == numCreated
     then pure .unit
-    else throw' (.balanceCheck s!"numConsumed: {numConsumed}/{consumed.length}, numCreated: {numCreated}/{created.length}")
+    else throw' (.balanceCheck { consumed
+                                 created
+                                 kind
+                                 kindCreated := getResourcesOfKind createdByKind kind
+                                 kindConsumed := getResourcesOfKind consumedByKind kind })
 
 def picks {A : Type u} (l : List A) : List (A × List A) :=
   List.finRange l.length |>.map (fun i => ⟨l.get i, l.eraseIdx i⟩)
@@ -131,7 +137,7 @@ def interpret : Program → RunM PUnit
       try do
         interpret b
         interpret next
-      catch err => interpret (handle (ULift.down err))
+      catch err => interpret (handle err)
   | .queryResource q next => do
     let s ← get
     match s.objects.get? q.uid with
@@ -146,7 +152,7 @@ def interpret : Program → RunM PUnit
     set {s with gen := gen1}
     next gen2 |>.interpret
 
-def eval {lab : AVM.Scope.Label} (scope : AVM.Scope lab) (p : Program) : EStateM.Result (ULift Program.Error) RmState PUnit :=
+def eval {lab : AVM.Scope.Label} (scope : AVM.Scope lab) (p : Program) : EStateM.Result Program.Error RmState PUnit :=
   let logics := Std.HashMap.ofList (scope.logics.map fun l => ⟨l.reference, l.function⟩)
   interpret p |>.run (RmState.ini logics)
 
@@ -161,5 +167,5 @@ def run {lab : AVM.Scope.Label} (scope : AVM.Scope lab) (p : Program) : IO Unit 
     IO.println "success"
   | .error err s => do
     printLogs s.logs
-    IO.println (repr err.down)
+    IO.println (repr err)
     IO.Process.exit 1

--- a/Anoma/Simulator.lean
+++ b/Anoma/Simulator.lean
@@ -32,7 +32,7 @@ abbrev RmState.ini (logics : Std.HashMap LogicRef LogicFunction) (gen : StdGen :
 
 /-- The evaluation monad -/
 abbrev RunM (a : Type 2) : Type 2 :=
-  EStateM (Program.Error) RmState a
+  EStateM Program.Error RmState a
 
 def logmsg (msg : String) : RunM PUnit :=
   modify (fun s => {s with logs := s.logs.cons msg})

--- a/Anoma/Simulator.lean
+++ b/Anoma/Simulator.lean
@@ -107,9 +107,9 @@ def runAction (a : SplitAction) : RunM PUnit := do
             Data := ⟨Unit⟩
             data := .unit }
         let logic <- fetchLogic self.logicRef
-        if logic args
-        then pure .unit
-        else throw' (.logicFailed self.logicRef)
+        match logic args with
+        | .ok _ => pure .unit
+        | .error err => throw' (.logicFailed self.logicRef err)
   for (r, consumed') in consumedPicks do
     checkLogic r .Consumed consumed' created
   for (r, created') in createdPicks do

--- a/Anoma/Simulator.lean
+++ b/Anoma/Simulator.lean
@@ -107,9 +107,9 @@ def runAction (a : SplitAction) : RunM PUnit := do
             Data := ⟨Unit⟩
             data := .unit }
         let logic <- fetchLogic self.logicRef
-        match logic args with
-        | .ok _ => pure .unit
-        | .error err => throw' (.logicFailed self.logicRef err)
+        match logic args |>.eval with
+        | none => pure .unit
+        | some err => throw' (.logicFailed self.logicRef err)
   for (r, consumed') in consumedPicks do
     checkLogic r .Consumed consumed' created
   for (r, created') in createdPicks do

--- a/Anoma/Simulator.lean
+++ b/Anoma/Simulator.lean
@@ -34,6 +34,9 @@ abbrev RmState.ini (logics : Std.HashMap LogicRef LogicFunction) (gen : StdGen :
 abbrev RunM (a : Type 2) : Type 2 :=
   EStateM (Program.Error) RmState a
 
+def logmsg (msg : String) : RunM PUnit :=
+  modify (fun s => {s with logs := s.logs.cons msg})
+
 def throw' {α : Type _} (e : Program.Error) : RunM α :=
   throw e
 
@@ -75,11 +78,9 @@ def storeLogic (ref : LogicRef) (f : LogicFunction) : RunM PUnit := do
 def storeCreated (created : List Resource) : RunM PUnit := do
   let created := created.filter (·.ephemeral.not)
   for r in created do
-    dbgTrace s!"created" (fun _ =>
     let try val : AVM.Object.Resource.SomeValue := tryCast r.value
-    dbgTrace s!"hi: {val.uid}" (fun _ =>
     modify (fun s => {s with objects := s.objects.insert val.uid r
-                             committed := s.committed.insert r.commitment})))
+                             committed := s.committed.insert r.commitment})
 
 
 def Action.split (a : Action) : SplitAction :=
@@ -117,9 +118,6 @@ def runAction (a : SplitAction) : RunM PUnit := do
   storeCreated created
   -- TODO nullify consumed
 
-def logmsg (msg : String) : RunM PUnit :=
-  modify (fun s => {s with logs := s.logs.cons msg})
-
 def runTransaction (t : Transaction) : RunM PUnit := do
   let actions : List SplitAction := t.actions |>.map Action.split
   checkDelta actions
@@ -152,7 +150,11 @@ def interpret : Program → RunM PUnit
     set {s with gen := gen1}
     next gen2 |>.interpret
 
-def eval {lab : AVM.Scope.Label} (scope : AVM.Scope lab) (p : Program) : EStateM.Result Program.Error RmState PUnit :=
+def eval
+  {lab : AVM.Scope.Label}
+  (scope : AVM.Scope lab)
+  (p : Program)
+  : EStateM.Result Program.Error RmState PUnit :=
   let logics := Std.HashMap.ofList (scope.logics.map fun l => ⟨l.reference, l.function⟩)
   interpret p |>.run (RmState.ini logics)
 

--- a/Applib/Surface/Program/Syntax.lean
+++ b/Applib/Surface/Program/Syntax.lean
@@ -16,7 +16,7 @@ def elabClosedNat (t : Syntax) : TacticM Nat := do
     reduceEval e
 
 def findProof (scope : Term) : TacticM Unit := do
-  let card <- elabClosedNat (← `(term| (AVM.Scope.Label.EcosystemIdEnum $scope).1))
+  let card <- elabClosedNat (← `(term| (AVM.Scope.Label.EcosystemIdEnum $scope).card))
   let f ← `(term| ($scope).EcosystemIdEnum.equiv.invFun)
   let possibleIndices : List (Fin card) := List.finRange card
   let tryN (n : Fin card) : TacticM Unit := do

--- a/Applib/Surface/Program/Syntax.lean
+++ b/Applib/Surface/Program/Syntax.lean
@@ -21,7 +21,7 @@ def findProof (scope : Term) : TacticM Unit := do
   let possibleIndices : List (Fin card) := List.finRange card
   let tryN (n : Fin card) : TacticM Unit := do
     let sn := Syntax.mkNumLit (toString n)
-    let labelId ← `(term| $f $sn)
+    let labelId : TSyntax `term ← `(term| $f $sn)
     let t ← `(tactic| try exact ⟨$labelId, by rfl⟩)
     evalTactic t
   for x in possibleIndices do

--- a/Apps/Kudos.lean
+++ b/Apps/Kudos.lean
@@ -16,7 +16,7 @@ open Applib
 structure KudosData where
   originator : AVM.PublicKey
   owner : AVM.PublicKey
-  deriving DecidableEq, Inhabited, Hashable
+  deriving DecidableEq, Inhabited, Hashable, Repr
 
 structure Kudos extends KudosData where
   quantity : Nat
@@ -85,14 +85,14 @@ instance hasTypeRep : TypeRep Kudos where
 structure MintArgs where
   originator : PublicKey
   quantity : Nat
-  deriving BEq, Hashable
+  deriving BEq, Hashable, Repr
 
 instance MintArgs.hasTypeRep : TypeRep MintArgs where
   rep := Rep.atomic "MintArgs"
 
 structure TransferArgs where
   newOwner : PublicKey
-  deriving DecidableEq, Hashable
+  deriving DecidableEq, Hashable, Repr
 
 instance TransferArgs.hasTypeRep : TypeRep TransferArgs where
   rep := Rep.atomic "TransferArgs"
@@ -130,7 +130,7 @@ inductive ArgNames where
 export ArgNames (Kudos1 Kudos2)
 
 structure Args where
-  deriving BEq, Hashable
+  deriving BEq, Hashable, Repr
 
 instance Args.hasTypeRep : TypeRep Args where
   rep := Rep.atomic "Kudos.Merge.Args"
@@ -147,7 +147,7 @@ export ArgNames (Kudos)
 
 structure Args where
   quantities : List Nat
-  deriving BEq, Hashable
+  deriving BEq, Hashable, Repr
 
 instance Args.hasTypeRep : TypeRep Args where
   rep := Rep.atomic "Kudos.Split.Args"

--- a/Apps/KudosBank.lean
+++ b/Apps/KudosBank.lean
@@ -11,11 +11,11 @@ def Std.HashMap.modifyDefault
 
 structure Denomination where
   originator : PublicKey
-  deriving BEq, Inhabited, Hashable, DecidableEq
+  deriving BEq, Inhabited, Hashable, DecidableEq, Repr
 
 structure Account where
   assets : Std.HashMap Denomination Nat
-  deriving BEq, Inhabited, Hashable
+  deriving BEq, Inhabited, Hashable, Repr
 
 namespace Account
 
@@ -41,7 +41,7 @@ end Account
 
 structure Balances where
   accounts : Std.HashMap PublicKey Account
-  deriving Inhabited, BEq, Hashable
+  deriving Inhabited, BEq, Hashable, Repr
 
 namespace Balances
 
@@ -66,7 +66,7 @@ structure Check where
   denomination : Denomination
   owner : PublicKey
   quantity : Nat
-  deriving BEq, Inhabited, Hashable
+  deriving BEq, Inhabited, Hashable, Repr
 
 namespace Check
 
@@ -81,7 +81,7 @@ inductive Methods where
 
 structure TransferArgs where
   newOwner : PublicKey
-  deriving DecidableEq, Hashable
+  deriving DecidableEq, Hashable, Repr
 
 instance TransferArgs.hasTypeRep : TypeRep TransferArgs where
   rep := Rep.atomic "Check.TransferArgs"
@@ -108,7 +108,7 @@ structure Auction where
   biddingDenomination : Denomination
   highestBid : Nat
   highestBidder : PublicKey
-  deriving BEq, Inhabited, Hashable
+  deriving BEq, Inhabited, Hashable, Repr
 
 namespace Auction
 
@@ -135,7 +135,7 @@ end Auction
 structure KudosBank where
   owner : PublicKey
   balances : Balances
-  deriving Inhabited, BEq, Hashable
+  deriving Inhabited, BEq, Hashable, Repr
 
 namespace KudosBank
 
@@ -210,7 +210,7 @@ instance hasTypeRep : TypeRep KudosBank where
 structure MintArgs where
   denom : Denomination
   quantity : Nat
-  deriving BEq, Hashable
+  deriving BEq, Hashable, Repr
 
 instance MintArgs.hasTypeRep : TypeRep MintArgs where
   rep := Rep.atomic "MintArgs"
@@ -227,7 +227,7 @@ structure TransferArgs where
   newOwner : PublicKey
   denom : Denomination
   quantity : Nat
-  deriving DecidableEq, Hashable
+  deriving DecidableEq, Hashable, Repr
 
 instance TransferArgs.hasTypeRep : TypeRep TransferArgs where
   rep := Rep.atomic "TransferArgs"
@@ -236,7 +236,7 @@ structure BurnArgs where
   denom : Denomination
   owner : PublicKey
   quantity : Nat
-  deriving DecidableEq, Hashable
+  deriving DecidableEq, Hashable, Repr
 
 instance BurnArgs.hasTypeRep : TypeRep BurnArgs where
   rep := Rep.atomic "BurnArgs"
@@ -273,7 +273,7 @@ structure Args where
   denomination : Denomination
   owner : PublicKey
   quantity : Nat
-  deriving BEq, Hashable
+  deriving BEq, Hashable, Repr
 
 inductive SignatureId : Type where
   | owner
@@ -291,7 +291,7 @@ end IssueCheck
 namespace DepositCheck
 
 structure Args where
-  deriving BEq, Hashable
+  deriving BEq, Hashable, Repr
 
 inductive SignatureId : Type where
   | owner
@@ -311,7 +311,7 @@ namespace NewAuction
 
 structure Args where
   biddingDenomination : Denomination
-  deriving BEq, Hashable
+  deriving BEq, Hashable, Repr
 
 inductive SignatureId : Type where
   | owner
@@ -329,7 +329,7 @@ end NewAuction
 namespace Bid
 
 structure Args where
-  deriving BEq, Hashable
+  deriving BEq, Hashable, Repr
 
 instance Args.hasTypeRep : TypeRep Args where
   rep := Rep.atomic "Bid.Args"
@@ -348,7 +348,7 @@ end Bid
 namespace EndAuction
 
 structure Args where
-  deriving BEq, Hashable
+  deriving BEq, Hashable, Repr
 
 inductive SignatureId : Type where
   | owner

--- a/Apps/UniversalCounter.lean
+++ b/Apps/UniversalCounter.lean
@@ -135,6 +135,7 @@ def counterEcosystem : Ecosystem label where
 
 def example1 : Applib.Program label.toScope Unit := ⟪
   c1 := create Counter Counter.Constructors.Zero ()
+  -- call Counter.Methods.Incr c1 (3 : Nat)
   return .unit
 ⟫
 

--- a/Apps/UniversalCounter.lean
+++ b/Apps/UniversalCounter.lean
@@ -135,7 +135,7 @@ def counterEcosystem : Ecosystem label where
 
 def example1 : Applib.Program label.toScope Unit := ⟪
   c1 := create Counter Counter.Constructors.Zero ()
-  -- call Counter.Methods.Incr c1 (3 : Nat)
+  -- call Counter.Methods.Incr c1 (3 : Nat) -- FIX issue #135
   return .unit
 ⟫
 

--- a/Prelude.lean
+++ b/Prelude.lean
@@ -1,3 +1,4 @@
+import Lean.Data.Json
 import Prelude.Check
 import Prelude.Debug
 import Prelude.FinEnum
@@ -15,4 +16,3 @@ import Prelude.SomeType
 import Prelude.TypeRep
 import Prelude.ULift
 import Prelude.Vector
-import Lean.Data.Json

--- a/Prelude.lean
+++ b/Prelude.lean
@@ -14,3 +14,4 @@ import Prelude.SomeType
 import Prelude.TypeRep
 import Prelude.ULift
 import Prelude.Vector
+import Lean.Data.Json

--- a/Prelude.lean
+++ b/Prelude.lean
@@ -1,4 +1,3 @@
-import Lean.Data.Json
 import Prelude.Check
 import Prelude.Debug
 import Prelude.FinEnum

--- a/Prelude.lean
+++ b/Prelude.lean
@@ -1,4 +1,5 @@
 import Prelude.Check
+import Prelude.Debug
 import Prelude.FinEnum
 import Prelude.FinEnum.Derive
 import Prelude.Function

--- a/Prelude/Check.lean
+++ b/Prelude/Check.lean
@@ -9,6 +9,11 @@ syntax withPosition("check " binderIdent " : " term) optSemicolon(term) : term
 syntax withPosition("check" term) optSemicolon(doSeq) : doElem
 syntax withPosition("check " binderIdent " : " term) optSemicolon(doSeq) : doElem
 
+syntax withPosition("check" term) withPosition("failwith" term) optSemicolon(term)? : term
+syntax withPosition("check " binderIdent " : " term) withPosition("failwith" term) optSemicolon(term) : term
+syntax withPosition("check" term) withPosition("failwith" doSeq) optSemicolon(doSeq) : doElem
+syntax withPosition("check " binderIdent " : " term) withPosition("failwith" doSeq) optSemicolon(doSeq) : doElem
+
 /-- The `check a; b` macro returns `b` if `a` evaluates to `true`, or `default`
   otherwise. -/
 macro_rules
@@ -22,3 +27,14 @@ macro_rules
   `(doElem| if $cond then $body else by mydefaultM)
 | `(doElem| check $h:ident : $cond:term ; $body:doSeq) =>
   `(doElem| if $h : $cond then $body else by mydefaultM)
+
+| `(check $cond:term failwith $f:term ; $body:term) =>
+  `(if $cond then $body else $f)
+| `(check $h:ident : $cond:term failwith $f:term ; $body:term) =>
+  `(if $h:ident : $cond then $body else $f)
+| `(check $cond:term failwith $f) =>
+  `(if $cond then true else $f)
+| `(doElem| check $cond:term failwith $f:doSeq ; $body:doSeq) =>
+  `(doElem| if $cond then $body else $f)
+| `(doElem| check $h:ident : $cond:term failwith $f:doSeq ; $body:doSeq) =>
+  `(doElem| if $h : $cond then $body else $f)

--- a/Prelude/Check.lean
+++ b/Prelude/Check.lean
@@ -1,8 +1,5 @@
-import Lean.Parser.Term
+import Prelude.Macro
 import Prelude.CustomDefault
-import Lean
-
-open Lean.Parser.Term
 
 syntax withPosition("check" term) optSemicolon(term)? : term
 syntax withPosition("check " binderIdent " : " term) optSemicolon(term) : term
@@ -11,8 +8,13 @@ syntax withPosition("check " binderIdent " : " term) optSemicolon(doSeq) : doEle
 
 syntax withPosition("check" term) withPosition("failwith" term) optSemicolon(term)? : term
 syntax withPosition("check " binderIdent " : " term) withPosition("failwith" term) optSemicolon(term) : term
-syntax withPosition("check" term) withPosition("failwith" doSeq) optSemicolon(doSeq) : doElem
-syntax withPosition("check " binderIdent " : " term) withPosition("failwith" doSeq) optSemicolon(doSeq) : doElem
+syntax withPosition("check" term) withPosition("failwith" term) optSemicolon(doSeq) : doElem
+
+syntax withPosition("docheck " binderIdent " : " term) withPosition("failwith" term) optSemicolon(doSeq) : doElem
+syntax withPosition("docheck" term) optSemicolon(doSeq) : doElem
+syntax withPosition("docheck " binderIdent " : " term) optSemicolon(doSeq) : doElem
+syntax withPosition("docheck" term) withPosition("failwith" term) optSemicolon(doSeq) : doElem
+
 
 /-- The `check a; b` macro returns `b` if `a` evaluates to `true`, or `default`
   otherwise. -/
@@ -23,9 +25,9 @@ macro_rules
   `(if $h:ident : $cond then $body else by mydefault)
 | `(check $cond:term) =>
   `($cond)
-| `(doElem| check $cond:term ; $body:doSeq) =>
+| `(doElem| docheck $cond:term ; $body:doSeq) =>
   `(doElem| if $cond then $body else by mydefaultM)
-| `(doElem| check $h:ident : $cond:term ; $body:doSeq) =>
+| `(doElem| docheck $h:ident : $cond:term ; $body:doSeq) =>
   `(doElem| if $h : $cond then $body else by mydefaultM)
 
 | `(check $cond:term failwith $f:term ; $body:term) =>
@@ -34,7 +36,13 @@ macro_rules
   `(if $h:ident : $cond then $body else $f)
 | `(check $cond:term failwith $f) =>
   `(if $cond then true else $f)
-| `(doElem| check $cond:term failwith $f:doSeq ; $body:doSeq) =>
-  `(doElem| if $cond then $body else $f)
-| `(doElem| check $h:ident : $cond:term failwith $f:doSeq ; $body:doSeq) =>
-  `(doElem| if $h : $cond then $body else $f)
+| `(doElem| docheck $cond:term failwith $f:term ; $body:doSeq) => do
+  let errDo : TSyntax `Lean.Parser.Term.doSeq ← doSeq1 (← `(term| $f))
+  `(doElem| if $cond then $body else $errDo)
+| `(doElem| docheck $h:ident : $cond:term failwith $f:term ; $body:doSeq) => do
+  let errDo : TSyntax `Lean.Parser.Term.doSeq ← doSeq1 (← `(term| $f))
+  `(doElem| if $h : $cond then $body else $errDo)
+
+example [Monad m] : m Unit := do
+  docheck 0 == 0
+  pure .unit

--- a/Prelude/Check.lean
+++ b/Prelude/Check.lean
@@ -1,4 +1,6 @@
 import Lean.Parser.Term
+import Prelude.CustomDefault
+import Lean
 
 open Lean.Parser.Term
 
@@ -11,12 +13,12 @@ syntax withPosition("check " binderIdent " : " term) optSemicolon(doSeq) : doEle
   otherwise. -/
 macro_rules
 | `(check $cond:term ; $body:term) =>
-  `(if $cond then $body else default)
+  `(if $cond then $body else by mydefault)
 | `(check $h:ident : $cond:term ; $body:term) =>
-  `(if $h:ident : $cond then $body else default)
+  `(if $h:ident : $cond then $body else by mydefault)
 | `(check $cond:term) =>
   `($cond)
 | `(doElem| check $cond:term ; $body:doSeq) =>
-  `(doElem| if $cond then $body else pure default)
+  `(doElem| if $cond then $body else by mydefaultM)
 | `(doElem| check $h:ident : $cond:term ; $body:doSeq) =>
-  `(doElem| if $h : $cond then $body else pure default)
+  `(doElem| if $h : $cond then $body else by mydefaultM)

--- a/Prelude/CustomDefault.lean
+++ b/Prelude/CustomDefault.lean
@@ -19,7 +19,7 @@ elab "mydefaultM" : tactic => do
    let tgt ← getMainTarget
    if tgt.isAppOf `LogicM
      then
-        let t ← `(tactic| exact (throw here#))
+        let t ← `(tactic| exact (throw (LogicM.Error.onlyPosition here#)))
         evalTactic t
      else do
       let t ← `(tactic| exact (pure default))

--- a/Prelude/CustomDefault.lean
+++ b/Prelude/CustomDefault.lean
@@ -1,0 +1,25 @@
+import Lean
+import Prelude.Debug
+
+open Lean
+open Elab.Tactic Meta
+
+elab "mydefault" : tactic => do
+   let tgt ← getMainTarget
+   if tgt.isAppOf `LogicM
+     then
+        let t ← `(tactic| exact (throw here#))
+        evalTactic t
+     else do
+      let t ← `(tactic| exact default)
+      evalTactic t
+
+elab "mydefaultM" : tactic => do
+   let tgt ← getMainTarget
+   if tgt.isAppOf `LogicM
+     then
+        let t ← `(tactic| exact (throw here#))
+        evalTactic t
+     else do
+      let t ← `(tactic| exact (pure default))
+      evalTactic t

--- a/Prelude/CustomDefault.lean
+++ b/Prelude/CustomDefault.lean
@@ -6,11 +6,9 @@ open Elab.Tactic Meta
 
 elab "mydefault" : tactic => do
    let tgt ← getMainTarget
-   -- logInfo s!"unchecked default {tgt}"
    if tgt.isAppOf `Anoma.LogicM
      then
-        -- logInfo "XXXXXXXX unchecked default"
-        let rawErr : TSyntax `term := mkIdent `Anoma.Logic.Error.rawError
+        let rawErr : TSyntax `term := mkIdent `Anoma.LogicM.Error.onlyPosition
         let t ← `(tactic| exact (throw ($rawErr here#)))
         evalTactic t
      else do
@@ -19,10 +17,8 @@ elab "mydefault" : tactic => do
 
 elab "mydefaultM" : tactic => do
    let tgt ← getMainTarget
-   -- logInfo "mydefaultM"
    if tgt.isAppOf `LogicM
      then
-        -- logInfo "MMMMMMM  unchecked default M"
         let t ← `(tactic| exact (throw here#))
         evalTactic t
      else do

--- a/Prelude/CustomDefault.lean
+++ b/Prelude/CustomDefault.lean
@@ -6,9 +6,12 @@ open Elab.Tactic Meta
 
 elab "mydefault" : tactic => do
    let tgt ← getMainTarget
-   if tgt.isAppOf `LogicM
+   -- logInfo s!"unchecked default {tgt}"
+   if tgt.isAppOf `Anoma.LogicM
      then
-        let t ← `(tactic| exact (throw here#))
+        -- logInfo "XXXXXXXX unchecked default"
+        let rawErr : TSyntax `term := mkIdent `Anoma.Logic.Error.rawError
+        let t ← `(tactic| exact (throw ($rawErr here#)))
         evalTactic t
      else do
       let t ← `(tactic| exact default)
@@ -16,8 +19,10 @@ elab "mydefault" : tactic => do
 
 elab "mydefaultM" : tactic => do
    let tgt ← getMainTarget
+   -- logInfo "mydefaultM"
    if tgt.isAppOf `LogicM
      then
+        -- logInfo "MMMMMMM  unchecked default M"
         let t ← `(tactic| exact (throw here#))
         evalTactic t
      else do

--- a/Prelude/Debug.lean
+++ b/Prelude/Debug.lean
@@ -1,0 +1,15 @@
+import Lean
+
+open Lean
+
+elab "here#" : term => do
+  let file ← getFileName
+  let ref ← getRef
+  let some pos := ref.getPos?
+    | return mkStrLit "<unknown position>"
+  let fm ← getFileMap
+  let lc := fm.toPosition pos
+  return mkStrLit s!"{file}:{lc.line}:{lc.column}"
+
+instance (priority := high) [Pure m] : Inhabited (ExceptT String m α) where
+  default := pure (f := m) (throw here#)

--- a/Prelude/Debug.lean
+++ b/Prelude/Debug.lean
@@ -2,14 +2,26 @@ import Lean
 
 open Lean
 
+structure FilePosition where
+  file : String
+  pos : Position
+  deriving ToExpr
+
+instance : Repr FilePosition where
+  reprPrec p _ := s!"{p.file}:{p.pos.line}:{p.pos.column}"
+
+def FilePosition.unknown : FilePosition where
+  file := "<unknown-file>"
+  pos := ⟨0, 0⟩
+
+-- returns FilePosition for the location where it is inserted
 elab "here#" : term => do
   let file ← getFileName
   let ref ← getRef
-  let some pos := ref.getPos?
-    | return mkStrLit "<unknown position>"
   let fm ← getFileMap
-  let lc := fm.toPosition pos
-  return mkStrLit s!"{file}:{lc.line}:{lc.column}"
-
-instance (priority := high) [Pure m] : Inhabited (ExceptT String m α) where
-  default := pure (f := m) (throw here#)
+  let some pos := ref.getPos?
+    | return (toExpr FilePosition.unknown)
+  let lc : FilePosition :=
+         { file
+           pos := fm.toPosition pos }
+  return (toExpr lc)

--- a/Prelude/FinEnum.lean
+++ b/Prelude/FinEnum.lean
@@ -49,6 +49,11 @@ def IsSomeDec {A} {a : A} {B : (a : A) → Type u} (m : Option (B a)) : Decidabl
   | none => isFalse (fun _ => by contradiction)
   | some _ => isTrue rfl
 
+def IsOkDec {A} {ε} {a : A} {B : (a : A) → Type u} (m : Except ε (B a)) : Decidable m.isOk :=
+  match m with
+  | .error _ => isFalse (fun _ => by contradiction)
+  | .ok _ => isTrue rfl
+
 def decImageOption {A : Type u} [FinEnum A] {B : (a : A) → Type v}
   (f : (a : A) -> Option (B a))
   : (∀ a : A, PLift ((f a).isSome)) ⊕ (Σ a : A, PLift (¬ (f a).isSome)) :=
@@ -63,6 +68,30 @@ def decImageOption' {A : Type u} [enum : FinEnum A] {B : (a : A) → Type v}
     match p1 : f a with
     | some b => b
     | none => by
+        have c := (p a).down
+        rw [p1] at c
+        contradiction
+
+def decImageExcept {A : Type u} [FinEnum A] {B : (a : A) → Type v}
+  (f : (a : A) -> Option (B a))
+  : (∀ a : A, PLift ((f a).isSome)) ⊕ (Σ a : A, PLift (¬ (f a).isSome)) :=
+  decImage f IsSomeDec
+
+def decImageExcept' {ε : Type w} {A : Type u} [enum : FinEnum A] {B : (a : A) → Type v}
+  (f : (a : A) -> Except ε (B a))
+  : Except ε (∀ a : A, B a) :=
+  match decImage f IsOkDec with
+  | .inr ⟨e, p⟩ => .error <|
+    match p1 : f e with
+    | .error e => e
+    | .ok _ => by
+      have c := p.down
+      rw [p1] at c
+      contradiction
+  | .inl p => .ok <| fun a =>
+    match p1 : f a with
+    | .ok b => b
+    | .error e => by
         have c := (p a).down
         rw [p1] at c
         contradiction

--- a/Prelude/LetBang.lean
+++ b/Prelude/LetBang.lean
@@ -1,12 +1,12 @@
 import Prelude.CustomDefault
 
 syntax withPosition("let!" term (":" term)? ":=" term) optSemicolon(term) : term
-syntax withPosition("dolet!" term ":=" term) optSemicolon(doSeq) : doElem
-syntax withPosition("dolet!" term ":" term ":=" term) optSemicolon(doSeq) : doElem
-syntax withPosition("dolet!" term (":" term)? "←" term)  optSemicolon(doSeq) : doElem
+syntax withPosition("let!" term ":=" term) optSemicolon(doSeq) : doElem
+syntax withPosition("let!" term ":" term ":=" term) optSemicolon(doSeq) : doElem
+syntax withPosition("let!" term (":" term)? "←" term)  optSemicolon(doSeq) : doElem
 syntax withPosition("let!" term (":" term)? ":=" term) withPosition("failwith" term) optSemicolon(term) : term
-syntax withPosition("dolet!" term (":" term)? ":=" term) withPosition("failwith" doSeq) optSemicolon(doSeq) : doElem
-syntax withPosition("dolet!" term (":" term)? "←" term) withPosition("failwith" doSeq) optSemicolon(doSeq) : doElem
+syntax withPosition("let!" term (":" term)? ":=" term) withPosition("failwith" doSeq) optSemicolon(doSeq) : doElem
+syntax withPosition("let!" term (":" term)? "←" term) withPosition("failwith" doSeq) optSemicolon(doSeq) : doElem
 
 /-- The `let! pat := v; b` syntax desugars to `match v with | pat => b | _ => default`.
   The value returned on failure (instead of `default`, when `v` does not match `pat`)
@@ -22,21 +22,21 @@ macro_rules
   `(match ($e) with | $x => $body | _ => $r)
 | `(let! $x:term : $t:term := $e:term failwith $r:term ; $body) =>
   `(match ($e) with | ($x : $t) => $body | _ => $r)
-| `(doElem| dolet! $x:term := $e:term ; $body:doSeq) =>
+| `(doElem| let! $x:term := $e:term ; $body:doSeq) =>
   `(doElem| match ($e) with | $x => $body | _ => by mydefaultM)
-| `(doElem| dolet! $x:term : $t:term := $e:term ; $body:doSeq) =>
+| `(doElem| let! $x:term : $t:term := $e:term ; $body:doSeq) =>
   `(doElem| match ($e) with | ($x : $t) => $body | _ => by mydefaultM)
-| `(doElem| dolet! $x:term := $e:term failwith $r:doSeq ; $body) =>
+| `(doElem| let! $x:term := $e:term failwith $r:doSeq ; $body) =>
   `(doElem| match ($e) with | $x => $body | _ => $r)
-| `(doElem| dolet! $x:term : $t:term := $e:term failwith $r:doSeq ; $body) =>
+| `(doElem| let! $x:term : $t:term := $e:term failwith $r:doSeq ; $body) =>
   `(doElem| match ($e) with | ($x : $t) => $body | _ => $r)
-| `(doElem| dolet! $x:term ← $e:term ; $body) =>
+| `(doElem| let! $x:term ← $e:term ; $body) =>
   `(doElem| match ← $e with | $x => $body | _ => by mydefaultM)
-| `(doElem| dolet! $x:term : $t:term ← $e:term ; $body) =>
+| `(doElem| let! $x:term : $t:term ← $e:term ; $body) =>
   `(doElem| match ← $e with | ($x : $t) => $body | _ => by mydefaultM)
-| `(doElem| dolet! $x:term ← $e:term failwith $r:doSeq ; $body) =>
+| `(doElem| let! $x:term ← $e:term failwith $r:doSeq ; $body) =>
   `(doElem| match ← $e with | $x => $body | _ => $r)
-| `(doElem| dolet! $x:term : $t:term ← $e:term failwith $r:doSeq ; $body) =>
+| `(doElem| let! $x:term : $t:term ← $e:term failwith $r:doSeq ; $body) =>
   `(doElem| match ← $e with | ($x : $t) => $body | _ => $r)
 
 /-

--- a/Prelude/LetBang.lean
+++ b/Prelude/LetBang.lean
@@ -1,3 +1,5 @@
+import Prelude.CustomDefault
+
 syntax withPosition("let!" term (":" term)? ":=" term) optSemicolon(term) : term
 syntax withPosition("let!" term ":=" term) optSemicolon(doSeq) : doElem
 syntax withPosition("let!" term ":" term ":=" term) optSemicolon(doSeq) : doElem
@@ -13,25 +15,25 @@ syntax withPosition("let!" term (":" term)? "←" term) withPosition("failwith" 
   The type of `pat` can be specified. -/
 macro_rules
 | `(let! $x:term := $e:term ; $body) =>
-  `(match ($e) with | $x => $body | _ => default)
+  `(match ($e) with | $x => $body | _ => by mydefault)
 | `(let! $x:term : $t:term := $e:term ; $body) =>
-  `(match ($e) with | ($x : $t) => $body | _ => default)
+  `(match ($e) with | ($x : $t) => $body | _ => by mydefault)
 | `(let! $x:term := $e:term failwith $r:term ; $body) =>
   `(match ($e) with | $x => $body | _ => $r)
 | `(let! $x:term : $t:term := $e:term failwith $r:term ; $body) =>
   `(match ($e) with | ($x : $t) => $body | _ => $r)
 | `(doElem| let! $x:term := $e:term ; $body:doSeq) =>
-  `(doElem| match ($e) with | $x => $body | _ => pure default)
+  `(doElem| match ($e) with | $x => $body | _ => by mydefaultM)
 | `(doElem| let! $x:term : $t:term := $e:term ; $body:doSeq) =>
-  `(doElem| match ($e) with | ($x : $t) => $body | _ => pure default)
+  `(doElem| match ($e) with | ($x : $t) => $body | _ => by mydefaultM)
 | `(doElem| let! $x:term := $e:term failwith $r:doSeq ; $body) =>
   `(doElem| match ($e) with | $x => $body | _ => $r)
 | `(doElem| let! $x:term : $t:term := $e:term failwith $r:doSeq ; $body) =>
   `(doElem| match ($e) with | ($x : $t) => $body | _ => $r)
 | `(doElem| let! $x:term ← $e:term ; $body) =>
-  `(doElem| match ← $e with | $x => $body | _ => pure default)
+  `(doElem| match ← $e with | $x => $body | _ => by mydefaultM)
 | `(doElem| let! $x:term : $t:term ← $e:term ; $body) =>
-  `(doElem| match ← $e with | ($x : $t) => $body | _ => pure default)
+  `(doElem| match ← $e with | ($x : $t) => $body | _ => by mydefaultM)
 | `(doElem| let! $x:term ← $e:term failwith $r:doSeq ; $body) =>
   `(doElem| match ← $e with | $x => $body | _ => $r)
 | `(doElem| let! $x:term : $t:term ← $e:term failwith $r:doSeq ; $body) =>

--- a/Prelude/LetBang.lean
+++ b/Prelude/LetBang.lean
@@ -1,12 +1,12 @@
 import Prelude.CustomDefault
 
 syntax withPosition("let!" term (":" term)? ":=" term) optSemicolon(term) : term
-syntax withPosition("let!" term ":=" term) optSemicolon(doSeq) : doElem
-syntax withPosition("let!" term ":" term ":=" term) optSemicolon(doSeq) : doElem
-syntax withPosition("let!" term (":" term)? "←" term)  optSemicolon(doSeq) : doElem
+syntax withPosition("dolet!" term ":=" term) optSemicolon(doSeq) : doElem
+syntax withPosition("dolet!" term ":" term ":=" term) optSemicolon(doSeq) : doElem
+syntax withPosition("dolet!" term (":" term)? "←" term)  optSemicolon(doSeq) : doElem
 syntax withPosition("let!" term (":" term)? ":=" term) withPosition("failwith" term) optSemicolon(term) : term
-syntax withPosition("let!" term (":" term)? ":=" term) withPosition("failwith" doSeq) optSemicolon(doSeq) : doElem
-syntax withPosition("let!" term (":" term)? "←" term) withPosition("failwith" doSeq) optSemicolon(doSeq) : doElem
+syntax withPosition("dolet!" term (":" term)? ":=" term) withPosition("failwith" doSeq) optSemicolon(doSeq) : doElem
+syntax withPosition("dolet!" term (":" term)? "←" term) withPosition("failwith" doSeq) optSemicolon(doSeq) : doElem
 
 /-- The `let! pat := v; b` syntax desugars to `match v with | pat => b | _ => default`.
   The value returned on failure (instead of `default`, when `v` does not match `pat`)
@@ -22,21 +22,21 @@ macro_rules
   `(match ($e) with | $x => $body | _ => $r)
 | `(let! $x:term : $t:term := $e:term failwith $r:term ; $body) =>
   `(match ($e) with | ($x : $t) => $body | _ => $r)
-| `(doElem| let! $x:term := $e:term ; $body:doSeq) =>
+| `(doElem| dolet! $x:term := $e:term ; $body:doSeq) =>
   `(doElem| match ($e) with | $x => $body | _ => by mydefaultM)
-| `(doElem| let! $x:term : $t:term := $e:term ; $body:doSeq) =>
+| `(doElem| dolet! $x:term : $t:term := $e:term ; $body:doSeq) =>
   `(doElem| match ($e) with | ($x : $t) => $body | _ => by mydefaultM)
-| `(doElem| let! $x:term := $e:term failwith $r:doSeq ; $body) =>
+| `(doElem| dolet! $x:term := $e:term failwith $r:doSeq ; $body) =>
   `(doElem| match ($e) with | $x => $body | _ => $r)
-| `(doElem| let! $x:term : $t:term := $e:term failwith $r:doSeq ; $body) =>
+| `(doElem| dolet! $x:term : $t:term := $e:term failwith $r:doSeq ; $body) =>
   `(doElem| match ($e) with | ($x : $t) => $body | _ => $r)
-| `(doElem| let! $x:term ← $e:term ; $body) =>
+| `(doElem| dolet! $x:term ← $e:term ; $body) =>
   `(doElem| match ← $e with | $x => $body | _ => by mydefaultM)
-| `(doElem| let! $x:term : $t:term ← $e:term ; $body) =>
+| `(doElem| dolet! $x:term : $t:term ← $e:term ; $body) =>
   `(doElem| match ← $e with | ($x : $t) => $body | _ => by mydefaultM)
-| `(doElem| let! $x:term ← $e:term failwith $r:doSeq ; $body) =>
+| `(doElem| dolet! $x:term ← $e:term failwith $r:doSeq ; $body) =>
   `(doElem| match ← $e with | $x => $body | _ => $r)
-| `(doElem| let! $x:term : $t:term ← $e:term failwith $r:doSeq ; $body) =>
+| `(doElem| dolet! $x:term : $t:term ← $e:term failwith $r:doSeq ; $body) =>
   `(doElem| match ← $e with | ($x : $t) => $body | _ => $r)
 
 /-

--- a/Prelude/LetTry.lean
+++ b/Prelude/LetTry.lean
@@ -1,4 +1,5 @@
 import Prelude.CustomDefault
+import Prelude.Macro
 
 syntax withPosition("let" "try" term (":" term)? ":=" term) optSemicolon(term) : term
 syntax withPosition("let" "try" term (":" term)? ":=" term) optSemicolon(doSeq) : doElem
@@ -11,7 +12,7 @@ syntax withPosition("let" "catch" term (":" term)? ":=" term) optSemicolon(term)
 syntax withPosition("let" "catch" term (":" term)? ":=" term) optSemicolon(doSeq) : doElem
 syntax withPosition("let" "catch" term (":" term)? "←" term)  optSemicolon(doSeq) : doElem
 syntax withPosition("let" "catch" term (":" term)? ":=" term) withPosition("failwith" term) optSemicolon(term) : term
-syntax withPosition("let" "catch" term (":" term)? ":=" term) withPosition("failwith" doSeq) optSemicolon(doSeq) : doElem
+syntax withPosition("let" "catch" term (":" term)? ":=" term) withPosition("failwith" term) optSemicolon(doSeq) : doElem
 syntax withPosition("let" "catch" term (":" term)? "←" term) withPosition("failwith" doSeq) optSemicolon(doSeq) : doElem
 
 /-- The `let try x := ov; b` macro unwraps an `Option`, for `ov = some v` binds
@@ -55,6 +56,17 @@ macro_rules
 | `(let catch $x:term : $t:term := $e:term failwith $r:term ; $body) =>
   `(match ($e) with | .error err => $r err | .ok ($x : $t) => $body)
 
+| `(doElem| let catch $x:term := $e:term ; $body) =>
+  `(doElem| match ($e) with | Except.error err => .error err | .ok $x => $body)
+| `(doElem| let catch $x:term : $t:term := $e:term ; $body) =>
+  `(doElem| match ($e) with | Except.error err => Except.error err | .ok ($x : $t) => $body)
+| `(doElem| let catch $x:term := $e:term failwith $r:term ; $body) => do
+  let errSeq : TSyntax `Lean.Parser.Term.doSeq ← doSeq1 (← `(term| $r err))
+  `(doElem| match ($e) with | Except.error err => $errSeq | .ok $x => $body)
+| `(doElem| let catch $x:term : $t:term := $e:term failwith $r:term ; $body) => do
+  let errSeq : TSyntax `Lean.Parser.Term.doSeq ← doSeq1 (← `(term| $r err))
+  `(doElem| match ($e) with | Except.error err => $errSeq | .ok ($x : $t) => $body)
+
 /-
 #eval let try x := some 42; some (x + 1)
 #eval let try y := some 10
@@ -64,3 +76,8 @@ macro_rules
 #eval let try _ : Nat := none; true
 #eval let try (_, y) := some (1, 2); some (y + 1)
 -/
+
+example : Except String Unit := do
+  let catch _num : Nat := throw "test"
+    failwith fun (err : String) => throw err
+  pure .unit

--- a/Prelude/LetTry.lean
+++ b/Prelude/LetTry.lean
@@ -7,6 +7,13 @@ syntax withPosition("let" "try" term (":" term)? ":=" term) withPosition("failwi
 syntax withPosition("let" "try" term (":" term)? ":=" term) withPosition("failwith" doSeq) optSemicolon(doSeq) : doElem
 syntax withPosition("let" "try" term (":" term)? "←" term) withPosition("failwith" doSeq) optSemicolon(doSeq) : doElem
 
+syntax withPosition("let" "catch" term (":" term)? ":=" term) optSemicolon(term) : term
+syntax withPosition("let" "catch" term (":" term)? ":=" term) optSemicolon(doSeq) : doElem
+syntax withPosition("let" "catch" term (":" term)? "←" term)  optSemicolon(doSeq) : doElem
+syntax withPosition("let" "catch" term (":" term)? ":=" term) withPosition("failwith" term) optSemicolon(term) : term
+syntax withPosition("let" "catch" term (":" term)? ":=" term) withPosition("failwith" doSeq) optSemicolon(doSeq) : doElem
+syntax withPosition("let" "catch" term (":" term)? "←" term) withPosition("failwith" doSeq) optSemicolon(doSeq) : doElem
+
 /-- The `let try x := ov; b` macro unwraps an `Option`, for `ov = some v` binds
   the value `v` to `x` in `b`, for `ov = none` returns `default`. The value
   returned on failure (when `ov = none`) can be specified with the `failwith`
@@ -38,6 +45,15 @@ macro_rules
   `(doElem| match ← $e with | none => $r | some $x => $body)
 | `(doElem| let try $x:term : $t:term ← $e:term failwith $r:doSeq ; $body) =>
   `(doElem| match ← $e with | none => $r | some ($x : $t) => $body)
+
+| `(let catch $x:term := $e:term ; $body) =>
+  `(match ($e) with | .error err => .error err | .ok $x => $body)
+| `(let catch $x:term : $t:term := $e:term ; $body) =>
+  `(match ($e) with | .error err => .error err | .ok ($x : $t) => $body)
+| `(let catch $x:term := $e:term failwith $r:term ; $body) =>
+  `(match ($e) with | .error err => $r err | some $x => $body)
+| `(let catch $x:term : $t:term := $e:term failwith $r:term ; $body) =>
+  `(match ($e) with | .error err => $r err | .ok ($x : $t) => $body)
 
 /-
 #eval let try x := some 42; some (x + 1)

--- a/Prelude/LetTry.lean
+++ b/Prelude/LetTry.lean
@@ -1,3 +1,5 @@
+import Prelude.CustomDefault
+
 syntax withPosition("let" "try" term (":" term)? ":=" term) optSemicolon(term) : term
 syntax withPosition("let" "try" term (":" term)? ":=" term) optSemicolon(doSeq) : doElem
 syntax withPosition("let" "try" term (":" term)? "←" term)  optSemicolon(doSeq) : doElem
@@ -13,25 +15,25 @@ syntax withPosition("let" "try" term (":" term)? "←" term) withPosition("failw
   The type of `x` can be specified and `x` can be an arbitrary match pattern. -/
 macro_rules
 | `(let try $x:term := $e:term ; $body) =>
-  `(match ($e) with | none => default | some $x => $body)
+  `(match ($e) with | none => by mydefault | some $x => $body)
 | `(let try $x:term : $t:term := $e:term ; $body) =>
-  `(match ($e) with | none => default | some ($x : $t) => $body)
+  `(match ($e) with | none => by mydefault | some ($x : $t) => $body)
 | `(let try $x:term := $e:term failwith $r:term ; $body) =>
   `(match ($e) with | none => $r | some $x => $body)
 | `(let try $x:term : $t:term := $e:term failwith $r:term ; $body) =>
   `(match ($e) with | none => $r | some ($x : $t) => $body)
 | `(doElem| let try $x:term := $e:term ; $body) =>
-  `(doElem| match ($e) with | none => default | some $x => $body)
+  `(doElem| match ($e) with | none => by mydefaultM | some $x => $body)
 | `(doElem| let try $x:term : $t:term := $e:term ; $body) =>
-  `(doElem| match ($e) with | none => default | some ($x : $t) => $body)
+  `(doElem| match ($e) with | none => by mydefaultM | some ($x : $t) => $body)
 | `(doElem| let try $x:term := $e:term failwith $r:doSeq ; $body) =>
   `(doElem| match ($e) with | none => $r | some $x => $body)
 | `(doElem| let try $x:term : $t:term := $e:term failwith $r:doSeq ; $body) =>
   `(doElem| match ($e) with | none => $r | some ($x : $t) => $body)
 | `(doElem| let try $x:term ← $e:term ; $body) =>
-  `(doElem| match ← $e with | none => default | some $x => $body)
+  `(doElem| match ← $e with | none => by mydefaultM | some $x => $body)
 | `(doElem| let try $x:term : $t:term ← $e:term ; $body) =>
-  `(doElem| match ← $e with | none => default | some ($x : $t) => $body)
+  `(doElem| match ← $e with | none => by mydefaultM | some ($x : $t) => $body)
 | `(doElem| let try $x:term ← $e:term failwith $r:doSeq ; $body) =>
   `(doElem| match ← $e with | none => $r | some $x => $body)
 | `(doElem| let try $x:term : $t:term ← $e:term failwith $r:doSeq ; $body) =>

--- a/Prelude/List.lean
+++ b/Prelude/List.lean
@@ -75,3 +75,6 @@ def zipWithM' {F : Type u → Type v} [Applicative F] (f : α → β → F γ) :
   | x :: xs, y :: ys => f x y *> zipWithM' f xs ys
   | [], _ => pure PUnit.unit
   | _, [] => pure PUnit.unit
+
+def unlines : List String → String :=
+  String.intercalate "\n"

--- a/Prelude/List.lean
+++ b/Prelude/List.lean
@@ -68,3 +68,10 @@ def splitsExact (lst : List A) (lengths : List Nat) : Option (SplitsType A lengt
   match splits lst lengths with
   | .some (l, []) => some l
   | _ => none
+
+-- Equivalent to zipWithM' in mathlib, but this one allows
+-- α and β to have different universe levels
+def zipWithM' {F : Type u → Type v} [Applicative F] (f : α → β → F γ) : List α → List β → F PUnit
+  | x :: xs, y :: ys => f x y *> zipWithM' f xs ys
+  | [], _ => pure PUnit.unit
+  | _, [] => pure PUnit.unit

--- a/Prelude/List.lean
+++ b/Prelude/List.lean
@@ -70,7 +70,7 @@ def splitsExact (lst : List A) (lengths : List Nat) : Option (SplitsType A lengt
   | _ => none
 
 -- Equivalent to zipWithM' in mathlib, but this one allows
--- α and β to have different universe levels
+-- α, β, γ to have different universe levels
 def zipWithM' {F : Type u → Type v} [Applicative F] (f : α → β → F γ) : List α → List β → F PUnit
   | x :: xs, y :: ys => f x y *> zipWithM' f xs ys
   | [], _ => pure PUnit.unit

--- a/Prelude/Macro.lean
+++ b/Prelude/Macro.lean
@@ -1,0 +1,13 @@
+import Lean.Parser.Do
+import Lean.Parser.Term
+
+open Lean
+open Parser
+open Term
+
+/-- Turn a `term` into a single-element `doSeq`. -/
+def doSeq1 (t : TSyntax `term) : MacroM (TSyntax ``doSeq) :=
+  `(doSeq| $t:term)
+
+export Lean (TSyntax)
+export Term (binderIdent)

--- a/Prelude/SomeType.lean
+++ b/Prelude/SomeType.lean
@@ -6,6 +6,7 @@ structure SomeType : Type (u + 1) where
   [typeTypeRep : TypeRep type]
   [typeBEq : BEq type]
   [typeHashable : Hashable type]
+  [typePretty : Repr type]
 
 instance SomeType.hasTypeRep : TypeRep SomeType where
   rep := Rep.atomic "SomeType"

--- a/Prelude/SomeType.lean
+++ b/Prelude/SomeType.lean
@@ -6,7 +6,7 @@ structure SomeType : Type (u + 1) where
   [typeTypeRep : TypeRep type]
   [typeBEq : BEq type]
   [typeHashable : Hashable type]
-  [typePretty : Repr type]
+  [typeRepr : Repr type]
 
 instance SomeType.hasTypeRep : TypeRep SomeType where
   rep := Rep.atomic "SomeType"

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -33,6 +33,6 @@ name = "Goose"
 name = "Tests"
 
 [[lean_exe]]
-name = "Runner"
+name = "counter"
 srcDir = "Apps"
 root = "UniversalCounter"


### PR DESCRIPTION
This PR fixes several bugs - mostly involving mismatches in “serialized” types. To make debugging easier, it changes the signature of the resource-logic function: it is now monadic, maintains a stack trace, and returns a descriptive error instead of simply `false` on failure.

I also fixed the monadic version of the `check` macro, which was not working correctly. I had to rename it to `docheck` to avoid conflicts with the term-level `check`.

Finally, I added a rather hacky mechanism, `mydefaultM`, to report the location of logic-function errors even when there is no explicit `failwith` clause. We should keep this for now but plan to remove it later.

I've also added a tiny example - a program with a single constructor call - that runs on CI.
